### PR TITLE
0.7.2 changelog and fixes #16 until 0.8 is released and can handle `~`

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+kolibri-source (0.7.2-0ubuntu1) trusty; urgency=medium
+
+  * New upstream release
+  * Remove KOLIBRI_HOME from /etc/default/kolibri #16
+
+ -- Benjamin Bach <benjamin@learningequality.org>  Tue, 27 Feb 2018 18:24:23 +0100
+
 kolibri-source (0.7.1-0ubuntu2) trusty; urgency=medium
 
   * Further Py3 support patches for source dist built on Python 2

--- a/debian/kolibri.scripts-common
+++ b/debian/kolibri.scripts-common
@@ -89,7 +89,7 @@ args=("$@")
 
 
 
-# This generates the contents of /etc/kolibri/system.conf so we don't have the
+# This generates the contents of /etc/kolibri/daemon.conf so we don't have the
 # file tracked by dpkg
 default_user_conf() {
 	cat <<EOF

--- a/debian/startup/kolibri.default
+++ b/debian/startup/kolibri.default
@@ -1,7 +1,9 @@
 # 1. Set the default values
 
 KOLIBRI_USER="kolibri"
-KOLIBRI_HOME="~/.kolibri"
+# This cannot have ~ until 0.8 where user home expansion is implemented
+# therefore leave it to its default until then
+# export KOLIBRI_HOME="~/.kolibri"
 KOLIBRI_LISTEN_PORT="8080"
 KOLIBRI_COMMAND="kolibri"
 DJANGO_SETTINGS_MODULE="kolibri.deployment.default.settings.base"


### PR DESCRIPTION
Releasing now on kolibri-proposed: https://launchpad.net/~learningequality/+archive/ubuntu/kolibri-proposed