### PR TITLE
Updates for the 0.8-0-ubuntu1 build

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,28 @@
+kolibri-source (0.8.0-0ubuntu1) trusty; urgency=medium
+
+  * Final 0.8.0 release
+  * Added patch for dbbackup crash when upgrading with "~" in KOLIBRI_HOME
+
+ -- Benjamin Bach <benjamin@learningequality.org>  Mon, 19 Mar 2018 19:00:28 +0100
+
+kolibri-source (0.8.0~b4-0ubuntu2) trusty; urgency=medium
+
+  * Fix attempt for replacing * with 0 in parse_version compat
+
+ -- Benjamin Bach <benjamin@learningequality.org>  Thu, 15 Mar 2018 00:31:11 +0100
+
+kolibri-source (0.8.0~b4-0ubuntu1) trusty; urgency=medium
+
+  * New upstream release
+
+ -- Benjamin Bach <benjamin@learningequality.org>  Wed, 14 Mar 2018 19:30:18 +0100
+
+kolibri-source (0.8.0~b3-0ubuntu1) trusty; urgency=medium
+
+  * New upstream beta
+
+ -- Benjamin Bach <benjamin@learningequality.org>  Tue, 13 Mar 2018 18:57:18 +0100
+
 kolibri-source (0.7.2-0ubuntu3) trusty; urgency=medium
 
   * Fix environment preservation inside system service for Ubuntu 14.04

--- a/debian/patches/expanduser.diff
+++ b/debian/patches/expanduser.diff
@@ -1,0 +1,11 @@
+--- a/kolibri/core/deviceadmin/utils.py
++++ b/kolibri/core/deviceadmin/utils.py
+@@ -29,7 +29,7 @@
+ 
+ 
+ def default_backup_folder():
+-    return os.path.join(os.environ['KOLIBRI_HOME'], 'backups')
++    return os.path.join(os.path.expanduser(os.environ['KOLIBRI_HOME']), 'backups')
+ 
+ 
+ def get_dtm_from_backup_name(fname):

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,4 +1,2 @@
-cherrypy-6.2.0.diff
+expanduser.diff
 rm-py2only.diff
-ifcfg.diff
-kolibri_exercise_perseus_plugin.diff

--- a/debian/startup/kolibri.default
+++ b/debian/startup/kolibri.default
@@ -1,9 +1,7 @@
 # 1. Set the default values
 
 KOLIBRI_USER="kolibri"
-# This cannot have ~ until 0.8 where user home expansion is implemented
-# therefore leave it to its default until then
-# export KOLIBRI_HOME="~/.kolibri"
+KOLIBRI_HOME="~/.kolibri"
 KOLIBRI_LISTEN_PORT="8080"
 KOLIBRI_COMMAND="kolibri"
 DJANGO_SETTINGS_MODULE="kolibri.deployment.default.settings.base"
@@ -37,4 +35,4 @@ export KOLIBRI_USER
 export KOLIBRI_LISTEN
 export KOLIBRI_COMMAND
 export DJANGO_SETTINGS_MODULE
-# export KOLIBRI_HOME
+export KOLIBRI_HOME


### PR DESCRIPTION
Fixes issues with `~` in KOLIBRI_HOME