### PR TITLE
Call py3clean to remove .pyc files for kolibri remove+purge

### DIFF
--- a/debian/kolibri.scripts-common
+++ b/debian/kolibri.scripts-common
@@ -303,4 +303,8 @@ kolibri_preinst()
 kolibri_prerm()
 {
     stop_kolibri_service
+
+    # Removes .pyc files in the Kolibri directory
+    # so that the Kolibri package can be completely removed later.
+    py3clean -p kolibri
 }


### PR DESCRIPTION
This PR includes an additional function in the `kolibri.scripts-common` -- `clean_kolibri_pyc`, which is called right after stopping the kolibri service during `remove+purge`. 

Removing all the .pyc files in the Kolibri directory can help us completely remove the Kolibri package when we call `apt-get remove kolibri` or `apt-get purge kolibri`. 

This should fix https://github.com/learningequality/kolibri-installer-debian/issues/21

I have tested on a Debian machine by installing kolibri from PPA, directly made changes to the `kolibri.prerm` and then removing kolibri by either `apt-get remove kolibri` or `apt-get purge kolibri`. The errors listed in the issue above don't exist in this case.

Please let me know if you find any problems. Thank you!