### PR TITLE
updates for 0.9.2-0ubuntu1 release

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+kolibri-source (0.9.2-0ubuntu1) trusty; urgency=medium
+
+  * Kolibri 0.9.2 release
+  * Change python3-distutils to be a recommendation instead of a dependency
+  * Modify the patch rm-py2only.diff depending on the files changed in futures module
+
+ -- Lingyi Wang <lingyi@learningequality.org>  Wed, 16 May 2018 22:18:29 +0000
+
 kolibri-source (0.9.1-0ubuntu2) trusty; urgency=medium
 
   * Add python3-distutils dependency

--- a/debian/control
+++ b/debian/control
@@ -30,9 +30,9 @@ Architecture: all
 Depends: python3 (<< 3.7),
          python3 (>= 3.4),
          python3-pkg-resources,
-         python3-distutils,
          adduser
-Recommends: python3-cryptography
+Recommends: python3-cryptography,
+            python3-distutils
 # Depends: ${python3:Depends}, ${misc:Depends}
 Description: The offline app for universal education
  An educational platform for learners of all ages.

--- a/debian/patches/rm-py2only.diff
+++ b/debian/patches/rm-py2only.diff
@@ -86,7 +86,7 @@
 -    pass
 --- a/kolibri/dist/py2only/concurrent/futures/_base.py
 +++ /dev/null
-@@ -1,667 +0,0 @@
+@@ -1,631 +0,0 @@
 -# Copyright 2009 Brian Quinlan. All Rights Reserved.
 -# Licensed to PSF under a Contributor Agreement.
 -
@@ -261,29 +261,6 @@
 -
 -    return waiter
 -
--
--def _yield_finished_futures(fs, waiter, ref_collect):
--    """
--    Iterate on the list *fs*, yielding finished futures one by one in
--    reverse order.
--    Before yielding a future, *waiter* is removed from its waiters
--    and the future is removed from each set in the collection of sets
--    *ref_collect*.
--
--    The aim of this function is to avoid keeping stale references after
--    the future is yielded and before the iterator resumes.
--    """
--    while fs:
--        f = fs[-1]
--        for futures_set in ref_collect:
--            futures_set.remove(f)
--        with f._condition:
--            f._waiters.remove(waiter)
--        del f
--        # Careful not to keep a reference to the popped value
--        yield fs.pop()
--
--
 -def as_completed(fs, timeout=None):
 -    """An iterator over the given futures that yields each as it completes.
 -
@@ -306,19 +283,16 @@
 -        end_time = timeout + time.time()
 -
 -    fs = set(fs)
--    total_futures = len(fs)
 -    with _AcquireFutures(fs):
 -        finished = set(
 -                f for f in fs
 -                if f._state in [CANCELLED_AND_NOTIFIED, FINISHED])
 -        pending = fs - finished
 -        waiter = _create_and_install_waiters(fs, _AS_COMPLETED)
--    finished = list(finished)
+-
 -    try:
--        for f in _yield_finished_futures(finished, waiter,
--                                         ref_collect=(fs,)):
--            f = [f]
--            yield f.pop()
+-        for future in finished:
+-            yield future
 -
 -        while pending:
 -            if timeout is None:
@@ -328,7 +302,7 @@
 -                if wait_timeout < 0:
 -                    raise TimeoutError(
 -                            '%d (of %d) futures unfinished' % (
--                            len(pending), total_futures))
+-                            len(pending), len(fs)))
 -
 -            waiter.event.wait(wait_timeout)
 -
@@ -337,15 +311,11 @@
 -                waiter.finished_futures = []
 -                waiter.event.clear()
 -
--            # reverse to keep finishing order
--            finished.reverse()
--            for f in _yield_finished_futures(finished, waiter,
--                                             ref_collect=(fs, pending)):
--                f = [f]
--                yield f.pop()
+-            for future in finished:
+-                yield future
+-                pending.remove(future)
 -
 -    finally:
--        # Remove waiter from unfinished futures
 -        for f in fs:
 -            with f._condition:
 -                f._waiters.remove(waiter)
@@ -441,20 +411,17 @@
 -        with self._condition:
 -            if self._state == FINISHED:
 -                if self._exception:
--                    return '<%s at %#x state=%s raised %s>' % (
--                        self.__class__.__name__,
--                        id(self),
+-                    return '<Future at %s state=%s raised %s>' % (
+-                        hex(id(self)),
 -                        _STATE_TO_DESCRIPTION_MAP[self._state],
 -                        self._exception.__class__.__name__)
 -                else:
--                    return '<%s at %#x state=%s returned %s>' % (
--                        self.__class__.__name__,
--                        id(self),
+-                    return '<Future at %s state=%s returned %s>' % (
+-                        hex(id(self)),
 -                        _STATE_TO_DESCRIPTION_MAP[self._state],
 -                        self._result.__class__.__name__)
--            return '<%s at %#x state=%s>' % (
--                    self.__class__.__name__,
--                    id(self),
+-            return '<Future at %s state=%s>' % (
+-                    hex(id(self)),
 -                   _STATE_TO_DESCRIPTION_MAP[self._state])
 -
 -    def cancel(self):
@@ -477,7 +444,7 @@
 -        return True
 -
 -    def cancelled(self):
--        """Return True if the future was cancelled."""
+-        """Return True if the future has cancelled."""
 -        with self._condition:
 -            return self._state in [CANCELLED, CANCELLED_AND_NOTIFIED]
 -
@@ -695,7 +662,7 @@
 -        raise NotImplementedError()
 -
 -    def map(self, fn, *iterables, **kwargs):
--        """Returns an iterator equivalent to map(fn, iter).
+-        """Returns a iterator equivalent to map(fn, iter).
 -
 -        Args:
 -            fn: A callable that will take as many arguments as there are
@@ -722,14 +689,11 @@
 -        # before the first iterator value is required.
 -        def result_iterator():
 -            try:
--                # reverse to keep finishing order
--                fs.reverse()
--                while fs:
--                    # Careful not to keep a reference to the popped future
+-                for future in fs:
 -                    if timeout is None:
--                        yield fs.pop().result()
+-                        yield future.result()
 -                    else:
--                        yield fs.pop().result(end_time - time.time())
+-                        yield future.result(end_time - time.time())
 -            finally:
 -                for future in fs:
 -                    future.cancel()
@@ -1122,7 +1086,7 @@
 -atexit.register(_python_exit)
 --- a/kolibri/dist/py2only/concurrent/futures/thread.py
 +++ /dev/null
-@@ -1,160 +0,0 @@
+@@ -1,149 +0,0 @@
 -# Copyright 2009 Brian Quinlan. All Rights Reserved.
 -# Licensed to PSF under a Contributor Agreement.
 -
@@ -1130,7 +1094,6 @@
 -
 -import atexit
 -from concurrent.futures import _base
--import itertools
 -import Queue as queue
 -import threading
 -import weakref
@@ -1216,17 +1179,12 @@
 -
 -
 -class ThreadPoolExecutor(_base.Executor):
--
--    # Used to assign unique thread names when thread_name_prefix is not supplied.
--    _counter = itertools.count().next
--
--    def __init__(self, max_workers=None, thread_name_prefix=''):
+-    def __init__(self, max_workers=None):
 -        """Initializes a new ThreadPoolExecutor instance.
 -
 -        Args:
 -            max_workers: The maximum number of threads that can be used to
 -                execute the given calls.
--            thread_name_prefix: An optional name prefix to give our threads.
 -        """
 -        if max_workers is None:
 -            # Use this number because ThreadPoolExecutor is often
@@ -1240,8 +1198,6 @@
 -        self._threads = set()
 -        self._shutdown = False
 -        self._shutdown_lock = threading.Lock()
--        self._thread_name_prefix = (thread_name_prefix or
--                                    ("ThreadPoolExecutor-%d" % self._counter()))
 -
 -    def submit(self, fn, *args, **kwargs):
 -        with self._shutdown_lock:
@@ -1263,11 +1219,8 @@
 -            q.put(None)
 -        # TODO(bquinlan): Should avoid creating new threads if there are more
 -        # idle threads than items in the work queue.
--        num_threads = len(self._threads)
--        if num_threads < self._max_workers:
--            thread_name = '%s_%d' % (self._thread_name_prefix or self,
--                                     num_threads)
--            t = threading.Thread(name=thread_name, target=_worker,
+-        if len(self._threads) < self._max_workers:
+-            t = threading.Thread(target=_worker,
 -                                 args=(weakref.ref(self, weakref_cb),
 -                                       self._work_queue))
 -            t.daemon = True


### PR DESCRIPTION
This PR includes updates for 0.9.2-0ubuntu1 release:
* kolibri 0.9.2 release
* updates the patch `rm-py2only.diff` based on the code changes in `kolibri/dist/py2only`
* moves `python3-distutils` from `depends` to `recommends` so that it's not a required dependency. This is because `python3-distutils` package only exists in [certain platforms](https://packages.ubuntu.com/search?keywords=python3-distutils). 
For example, the issue existed in Ubuntu 16.04: https://community.learningequality.org/t/failed-to-install-on-lubuntu-16-04-lightweight-ubuntu/625/3