### PR TITLE
Fix KOLIBRI_LISTEN_PORT exported from /etc/kolibri/daemon.conf

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kolibri-source (0.9.2-0ubuntu4) trusty; urgency=medium
+
+  * Fix KOLIBRI_LISTEN_PORT in /etc/kolibri/daemon.conf
+
+ -- Benjamin Bach <benjamin@learningequality.org>  Mon, 04 Jun 2018 16:36:42 +0200
+
 kolibri-source (0.9.2-0ubuntu3) trusty; urgency=medium
 
   * Remove "Recommends: python3-distutils"

--- a/debian/startup/kolibri.default
+++ b/debian/startup/kolibri.default
@@ -32,7 +32,7 @@ fi
 # Will be investigated in 0.8.x when setting a path relative to "~" is
 # supported.
 export KOLIBRI_USER
-export KOLIBRI_LISTEN
+export KOLIBRI_LISTEN_PORT
 export KOLIBRI_COMMAND
 export DJANGO_SETTINGS_MODULE
 export KOLIBRI_HOME


### PR DESCRIPTION
Fixes learningequality/kolibri#3750