### PR TITLE
Update for release 0.9.3~b1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kolibri-source (0.9.3~b1-0ubuntu1) trusty; urgency=medium
+
+  * Beta release for Kolibri 0.9.3
+
+ -- Lingyi Wang <lingyi@learningequality.org>  Wed, 13 Jun 2018 17:32:13 +0000
+
 kolibri-source (0.9.2-0ubuntu4) trusty; urgency=medium
 
   * Fix KOLIBRI_LISTEN_PORT in /etc/kolibri/daemon.conf

--- a/debian/control
+++ b/debian/control
@@ -30,7 +30,6 @@ Architecture: all
 Depends: python3 (<< 3.7),
          python3 (>= 3.4),
          python3-pkg-resources,
-         python3-distutils | libpython3-stdlib (<< 3.6.5),
          adduser
 Recommends: python3-cryptography
 Description: The offline app for universal education


### PR DESCRIPTION
To keep up with the `kolibri-proposed` PPA releases, I only put the change for `0.9.3~b1` here, since we built the 0.10.0 betas locally. 

The only change for this PR is to remove `python3-distutils` from required dependencies. 

Please let me know if I need to make additional changes. Thanks!