### PR TITLE
Update changelog for 0.10.2

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,15 @@
+kolibri-source (0.10.2-0ubuntu1) trusty; urgency=medium
+
+  * New upstream release
+
+ -- Lingyi Wang <lingyi@learningequality.org>  Fri, 24 Aug 2018 01:17:16 +0000
+
+kolibri-source (0.10.1-0ubuntu1) trusty; urgency=medium
+
+  * New upstream release
+
+ -- Benjamin Bach <benjamin@learningequality.org>  Sun, 05 Aug 2018 22:34:45 +0200
+
 kolibri-source (0.10.1~b1-0ubuntu1) trusty; urgency=medium
 
   * New upstream release


### PR DESCRIPTION
Changelog is the only change for this Kolibri 0.10.2 release.

(Looks like 0.10.1's change hasn't been in the repository yet? @benjaoming)