### PR TITLE
Dropping Python 3.7 constraint for 0.11.1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kolibri-source (0.11.1~0.dev0+git.20190108231430-0ubuntu2) trusty; urgency=medium
+
+  * Removing upper limit on Python 3 that prohibited Python 3.7
+
+ -- Benjamin Bach <benjamin@learningequality.org>  Fri, 11 Jan 2019 20:16:04 +0100
+
 kolibri-source (0.11.1~0.dev0+git.20190108231430-0ubuntu1) trusty; urgency=medium
 
   * Removing upper limit on Python 3 that prohibited Python 3.7

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,31 @@
+kolibri-source (0.11.1~0.dev0+git.20190108231430-0ubuntu1) trusty; urgency=medium
+
+  * Removing upper limit on Python 3 that prohibited Python 3.7
+
+ -- Benjamin Bach <benjamin@learningequality.org>  Fri, 11 Jan 2019 16:19:34 +0100
+
+kolibri-source (0.11.0-0ubuntu1) trusty; urgency=medium
+
+  * New upstream release 
+
+ --  Lingyi Wang <lingyi@learningequality.org>  Tue, 06 Nov 2018 22:39:29 +0000
+
+kolibri-source (0.11.0~b2-0ubuntu1) trusty; urgency=medium
+
+  * New beta release for Kolibri 0.11
+
+ --  Lingyi Wang <lingyi@learningequality.org>  Wed, 17 Oct 2018 19:33:27 +0000
+
+kolibri-source (0.10.3-0ubuntu1) trusty; urgency=medium
+
+  * New upstream release
+  * Fixes from 0.9.5 have entered 0.10.3
+  * Mexican Spanish and Bulgarian added
+  * Several bug fixes
+  * Details upstream: https://github.com/learningequality/kolibri/pulls?q=is%3Apr+milestone%3A0.10.3
+
+ --  <benjamin+buildserver@learningequality.org>  Tue, 16 Oct 2018 21:46:54 +0000
+
 kolibri-source (0.10.2-0ubuntu1) trusty; urgency=medium
 
   * New upstream release

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,14 +1,9 @@
-kolibri-source (0.11.1~0.dev0+git.20190108231430-0ubuntu2) trusty; urgency=medium
+kolibri-source (0.11.1-0ubuntu1) trusty; urgency=medium
 
+  * New upstream release
   * Removing upper limit on Python 3 that prohibited Python 3.7
 
- -- Benjamin Bach <benjamin@learningequality.org>  Fri, 11 Jan 2019 20:16:04 +0100
-
-kolibri-source (0.11.1~0.dev0+git.20190108231430-0ubuntu1) trusty; urgency=medium
-
-  * Removing upper limit on Python 3 that prohibited Python 3.7
-
- -- Benjamin Bach <benjamin@learningequality.org>  Fri, 11 Jan 2019 16:19:34 +0100
+ -- Benjamin Bach <benjamin@learningequality.org>  Mon, 14 Jan 2019 21:54:45 +0100
 
 kolibri-source (0.11.0-0ubuntu1) trusty; urgency=medium
 

--- a/debian/control
+++ b/debian/control
@@ -27,8 +27,7 @@ Vcs-Browser: https://github.com/learningequality/kolibri-installer-debian
 
 Package: kolibri
 Architecture: all
-Depends: python3 (<< 3.7),
-         python3 (>= 3.4),
+Depends: python3 (>= 3.4),
          python3-pkg-resources,
          adduser
 Recommends: python3-cryptography

--- a/debian/kolibri.templates
+++ b/debian/kolibri.templates
@@ -13,7 +13,7 @@ Template: kolibri/init-instructions
 Type: note
 Description: The Kolibri system service
  You have chosen to run Kolibri as a system
- service and it will be started automatically. You can
+ service and it has been started automatically. You can
  start/stop/restart Kolibri with the following command
  .
    sudo service kolibri [start, stop, restart]


### PR DESCRIPTION
CC: @lyw07 

Ref: https://github.com/learningequality/kolibri/issues/4548