### PR TITLE
Add default primary system group and add one for existing users

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kolibri-source (0.11.1-0ubuntu3) trusty; urgency=medium
+
+  * Fixes primary user group on existing system service owners
+
+ -- Benjamin Bach <benjamin@learningequality.org>  Sun, 10 Feb 2019 02:24:34 +0100
+
 kolibri-source (0.11.1-0ubuntu2) trusty; urgency=medium
 
   * Create a primary user group for the kolibri system service owner

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,9 +1,15 @@
+kolibri-source (0.11.1-0ubuntu2) trusty; urgency=medium
+
+  * Create a primary user group for the kolibri system service owner
+
+ -- Benjamin Bach <benjamin@learningequality.org>  Sun, 10 Feb 2019 01:37:00 +0100
+
 kolibri-source (0.11.1-0ubuntu1) trusty; urgency=medium
 
   * New upstream release
   * Removing upper limit on Python 3 that prohibited Python 3.7
 
- -- Benjamin Bach <benjamin@learningequality.org>  Mon, 14 Jan 2019 21:54:45 +0100
+ -- Benjamin Bach <benjamin@learningequality.org>  Mon, 14 Jan 2019 23:40:04 +0100
 
 kolibri-source (0.11.0-0ubuntu1) trusty; urgency=medium
 

--- a/debian/kolibri.scripts-common
+++ b/debian/kolibri.scripts-common
@@ -247,8 +247,28 @@ kolibri_configure()
     # while using errexit
     ( ! getent passwd "$KOLIBRI_USER" 1>/dev/null ) && {
         echo "Creating new user $KOLIBRI_USER"
-        adduser --system --shell /bin/bash --home "/var/$KOLIBRI_USER" "$KOLIBRI_USER"
+        adduser --system --group --shell /bin/bash --home "/var/$KOLIBRI_USER" "$KOLIBRI_USER"
     }
+
+    # Sets the primary user group for previous installations w/o one
+    # THIS CAN BE DEPRECATED ONCE WE DO NOT WANT TO SUPPORT DIRECT UPGRADES FROM
+    # RELEASES BEFORE 0.11.1-ubuntu1.
+    if [ "${args[0]}" = "upgrade" ]
+    then
+        # Ensure that a primary system group for the "kolibri" user is created
+        KOLIBRI_USER_GROUP=`id "$KOLIBRI_USER" -g`
+        if [ "$KOLIBRI_USER_GROUP" = "65534" ]
+        then
+            if getent group "$KOLIBRI_USER" 1>/dev/null
+            then
+                new_group_name="${KOLIBRI_USER}_group"
+            else
+                new_group_name="$KOLIBRI_USER"
+            fi
+            addgroup --system "$new_group_name"
+            usermod -g "$KOLIBRI_USER" "$new_group_name"
+        fi
+    fi
 
     # After the user has been successfully created, save it in the configuration
     # for the system service.

--- a/debian/kolibri.scripts-common
+++ b/debian/kolibri.scripts-common
@@ -253,21 +253,17 @@ kolibri_configure()
     # Sets the primary user group for previous installations w/o one
     # THIS CAN BE DEPRECATED ONCE WE DO NOT WANT TO SUPPORT DIRECT UPGRADES FROM
     # RELEASES BEFORE 0.11.1-ubuntu1.
-    if [ "${args[0]}" = "upgrade" ]
+    KOLIBRI_USER_GROUP=`id "$KOLIBRI_USER" -g`
+    if [ "$KOLIBRI_USER_GROUP" = "65534" ]
     then
-        # Ensure that a primary system group for the "kolibri" user is created
-        KOLIBRI_USER_GROUP=`id "$KOLIBRI_USER" -g`
-        if [ "$KOLIBRI_USER_GROUP" = "65534" ]
+        if getent group "$KOLIBRI_USER" 1>/dev/null
         then
-            if getent group "$KOLIBRI_USER" 1>/dev/null
-            then
-                new_group_name="${KOLIBRI_USER}_group"
-            else
-                new_group_name="$KOLIBRI_USER"
-            fi
-            addgroup --system "$new_group_name"
-            usermod -g "$KOLIBRI_USER" "$new_group_name"
+            new_group_name="${KOLIBRI_USER}_group"
+        else
+            new_group_name="$KOLIBRI_USER"
         fi
+        addgroup --system "$new_group_name"
+        usermod -g "$KOLIBRI_USER" "$new_group_name"
     fi
 
     # After the user has been successfully created, save it in the configuration


### PR DESCRIPTION
Fixes #60 

Tested on:

1) User with an existing group
2) New user
3) User without an existing group