### PR TITLE
Set KOLIBRI_HOME unambiguously

### DIFF
--- a/debian/startup/kolibri.default
+++ b/debian/startup/kolibri.default
@@ -22,7 +22,7 @@ else
   export KOLIBRI_USER="kolibri"
 fi
 
-KOLIBRI_HOME="~/.kolibri"
+KOLIBRI_HOME="$(getent passwd $KOLIBRI_USER | awk -F ':' '{print $6}')/.kolibri"
 KOLIBRI_COMMAND="kolibri"
 DJANGO_SETTINGS_MODULE="kolibri.deployment.default.settings.base"
 


### PR DESCRIPTION
This PR changes the way KOLIBRI_HOME is calculated to avoid any kind of ambiguity.
Currently the output of this envvar depends on the user it loads the default values.

Closes #62 