### PR TITLE
add changelog entry for 0.12.8 and remove the ones for betas

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kolibri-source (0.12.8-0ubuntu1) trusty; urgency=medium
+
+  * Kolibri v0.12.8 is released! Read the changes here: https://github.com/learningequality/kolibri/blob/v0.12.8/CHANGELOG.md#0128
+
+ -- Lingyi Wang <lingyi@learningequality.org>  Thu, 15 Aug 2019 00:17:29 -0400
+
 kolibri-source (0.12.7-0ubuntu1) trusty; urgency=medium
 
   * Kolibri v0.12.7 is released! Read the changes here: https://github.com/learningequality/kolibri/blob/v0.12.7/CHANGELOG.md#0127
@@ -25,45 +31,9 @@ kolibri-source (0.12.5-0ubuntu1) trusty; urgency=medium
 kolibri-source (0.12.4-0ubuntu1) bionic; urgency=low
 
   * New upstream release
-
- -- José L. Redrejo Rodríguez <jredrejo@debian.org>  Wed, 12 Jun 2019 20:25:59 +0200
-
-kolibri-source (0.12.4~b7-0ubuntu2) bionic; urgency=medium
-
-  * New upstream pre-release
   * debian/rules: remove sentry tornado file
 
- -- José L. Redrejo Rodríguez <jredrejo@debian.org>  Tue, 11 Jun 2019 17:50:20 +0200
-
-kolibri-source (0.12.4~b7-0ubuntu1) trusty; urgency=medium
-
-  * New upstream pre-release
-
- -- Lingyi Wang <lingyi@learningequality.org>  Fri, 07 Jun 2019 00:58:02 -0400
-
-kolibri-source (0.12.4~b6-0ubuntu1) bionic; urgency=low
-
-  * New upstream pre-release
-
- -- José L. Redrejo Rodríguez <jredrejo@debian.org>  Fri, 31 May 2019 10:49:14 +0200
-
-kolibri-source (0.12.4~b5-0ubuntu1) bionic; urgency=low
-
-  * New upstream pre-release
-
- -- José L. Redrejo Rodríguez <jredrejo@debian.org>  Thu, 30 May 2019 11:50:26 +0200
-
-kolibri-source (0.12.4~b3-0ubuntu1) trusty; urgency=medium
-
-  * New upstream pre-release
-
- -- Lingyi Wang <lingyi@learningequality.org>  Tue, 21 May 2019 21:11:00 -0400
-
-kolibri-source (0.12.4~b2-0ubuntu1) trusty; urgency=medium
-
-  * New upstream pre-release
-
- -- Lingyi Wang <lingyi@learningequality.org>  Tue, 21 May 2019 14:29:42 -0400
+ -- José L. Redrejo Rodríguez <jredrejo@debian.org>  Wed, 12 Jun 2019 20:25:59 +0200
 
 kolibri-source (0.12.3-0ubuntu1) trusty; urgency=medium
 
@@ -96,56 +66,12 @@ kolibri-source (0.12.0-0ubuntu1) trusty; urgency=medium
 
  -- Lingyi Wang <lingyi@learningequality.org>  Mon, 04 Mar 2019 19:16:29 -0500
 
-kolibri-source (0.12.0~b10-0ubuntu1) trusty; urgency=medium
-
-  * New upstream pre-release
-
- -- Benjamin Bach <benjamin@learningequality.org>  Wed, 27 Feb 2019 18:37:10 +0100
-
-kolibri-source (0.12.0~b9-0ubuntu1) trusty; urgency=medium
-
-  * New upstream pre-release
-
- -- Benjamin Bach <benjamin@learningequality.org>  Mon, 25 Feb 2019 22:41:03 +0100
-
-kolibri-source (0.12.0~b8-0ubuntu1) trusty; urgency=medium
-
-  * New upstream pre-release
-
- -- Benjamin Bach <benjamin@learningequality.org>  Thu, 21 Feb 2019 18:08:37 +0100
-
-kolibri-source (0.12.0~b7-0ubuntu1) trusty; urgency=medium
-
-  * New upstream pre-release
-
- -- Benjamin Bach <benjamin@learningequality.org>  Sat, 16 Feb 2019 14:50:45 +0100
-
-kolibri-source (0.12.0~b5-0ubuntu1) trusty; urgency=medium
-
-  * New upstream pre-release
-
- -- Benjamin Bach <benjamin@learningequality.org>  Thu, 14 Feb 2019 15:34:13 +0100
-
-kolibri-source (0.12.0~b4-0ubuntu2) trusty; urgency=medium
-
-  * Add a hotfix for disallowed version tuple in beta4
-
- -- Benjamin Bach <benjamin@learningequality.org>  Sun, 10 Feb 2019 20:04:16 +0100
-
-kolibri-source (0.12.0~b4-0ubuntu1) trusty; urgency=medium
-
-  * New upstream pre-release
-
- -- Benjamin Bach <benjamin@learningequality.org>  Sun, 10 Feb 2019 19:32:25 +0100
-
-
 kolibri-source (0.11.1-0ubuntu4) trusty; urgency=medium
 
   * Fix for KOLIBRI_HOME wrongly set if run in certain sudo environments #62
   * Spanish translation of debian installation process #59
 
  -- Benjamin Bach <benjamin@learningequality.org>  Thu, 14 Feb 2019 21:04:19 +0100
-
 
 kolibri-source (0.11.1-0ubuntu3) trusty; urgency=medium
 
@@ -172,12 +98,6 @@ kolibri-source (0.11.0-0ubuntu1) trusty; urgency=medium
 
  --  Lingyi Wang <lingyi@learningequality.org>  Tue, 06 Nov 2018 22:39:29 +0000
 
-kolibri-source (0.11.0~b2-0ubuntu1) trusty; urgency=medium
-
-  * New beta release for Kolibri 0.11
-
- --  Lingyi Wang <lingyi@learningequality.org>  Wed, 17 Oct 2018 19:33:27 +0000
-
 kolibri-source (0.10.3-0ubuntu1) trusty; urgency=medium
 
   * New upstream release
@@ -197,17 +117,11 @@ kolibri-source (0.10.2-0ubuntu1) trusty; urgency=medium
 kolibri-source (0.10.1-0ubuntu1) trusty; urgency=medium
 
   * New upstream release
-
- -- Benjamin Bach <benjamin@learningequality.org>  Sun, 05 Aug 2018 22:34:45 +0200
-
-kolibri-source (0.10.1~b1-0ubuntu1) trusty; urgency=medium
-
-  * New upstream release
   * Adding a test that KOLIBRI_USER is set in init script
   * Do not set KOLIBRI_HTTP_PORT (or deprecated KOLIBRI_LISTEN_PORT), use just 8080 default
   * Export all known env variables in case they are user defined in /etc/kolibri
 
- -- Benjamin Bach <benjamin@learningequality.org>  Thu, 02 Aug 2018 19:10:56 +0200
+ -- Benjamin Bach <benjamin@learningequality.org>  Sun, 05 Aug 2018 22:34:45 +0200
 
 kolibri-source (0.10.0-0ubuntu2) trusty; urgency=medium
 
@@ -219,42 +133,14 @@ kolibri-source (0.10.0-0ubuntu2) trusty; urgency=medium
 kolibri-source (0.10.0-0ubuntu1) trusty; urgency=medium
 
   * New stable upstream release
-
- -- Benjamin Bach <benjamin@learningequality.org>  Thu, 05 Jul 2018 11:57:35 +0200
-
-kolibri-source (0.10.0~b10-0ubuntu1) trusty; urgency=medium
-
-  * New upstream release
   * Changed URL upgrade note for changing system service owner
-
- -- Benjamin Bach <benjamin@learningequality.org>  Tue, 03 Jul 2018 17:22:10 +0200
-
-kolibri-source (0.10.0~b9-0ubuntu2) trusty; urgency=medium
-
   * Display a note for upgrades from <0.10
-
- -- Benjamin Bach <benjamin@learningequality.org>  Mon, 02 Jul 2018 23:47:00 +0200
-
-kolibri-source (0.10.0~b9-0ubuntu1) trusty; urgency=medium
-
-  * New upstream release
-  * Upgrade notes for pre 0.0.10
-
- -- Benjamin Bach <benjamin@learningequality.org>  Mon, 02 Jul 2018 22:01:37 +0200
-
-kolibri-source (0.10.0~b8-0ubuntu2) trusty; urgency=medium
-
+  * Upgrade notes for pre 0.10.0
   * Only set defaults during install, not for upgrades
-
- -- Benjamin Bach <benjamin@learningequality.org>  Fri, 29 Jun 2018 16:07:51 +0200
-
-kolibri-source (0.10.0~b8-0ubuntu1) trusty; urgency=medium
-
-  * New upstream release
   * Use desktop user for system service and prompt through debconf
   * Removed python3-distutils dependency
 
- -- Benjamin Bach <benjamin@learningequality.org>  Fri, 29 Jun 2018 00:52:18 +0200
+ -- Benjamin Bach <benjamin@learningequality.org>  Thu, 05 Jul 2018 11:57:35 +0200
 
 kolibri-source (0.9.2-0ubuntu4) trusty; urgency=medium
 
@@ -312,36 +198,13 @@ kolibri-source (0.9.0-0ubuntu1) trusty; urgency=medium
 
  -- Lingyi Wang <lingyi@learningequality.org>  Thu, 29 Mar 2018 19:11:02 +0000
 
-kolibri-source (0.9.0~b2-0ubuntu1) trusty; urgency=medium
-
-  * New upstream release
-
- -- Benjamin Bach <benjamin@learningequality.org>  Mon, 26 Mar 2018 22:58:11 +0200
-
 kolibri-source (0.8.0-0ubuntu1) trusty; urgency=medium
 
   * Final 0.8.0 release
   * Added patch for dbbackup crash when upgrading with "~" in KOLIBRI_HOME
-
- -- Benjamin Bach <benjamin@learningequality.org>  Mon, 19 Mar 2018 19:00:28 +0100
-
-kolibri-source (0.8.0~b4-0ubuntu2) trusty; urgency=medium
-
   * Fix attempt for replacing * with 0 in parse_version compat
 
- -- Benjamin Bach <benjamin@learningequality.org>  Thu, 15 Mar 2018 00:31:11 +0100
-
-kolibri-source (0.8.0~b4-0ubuntu1) trusty; urgency=medium
-
-  * New upstream release
-
- -- Benjamin Bach <benjamin@learningequality.org>  Wed, 14 Mar 2018 19:30:18 +0100
-
-kolibri-source (0.8.0~b3-0ubuntu1) trusty; urgency=medium
-
-  * New upstream beta
-
- -- Benjamin Bach <benjamin@learningequality.org>  Tue, 13 Mar 2018 18:57:18 +0100
+ -- Benjamin Bach <benjamin@learningequality.org>  Mon, 19 Mar 2018 19:00:28 +0100
 
 kolibri-source (0.7.2-0ubuntu3) trusty; urgency=medium
 
@@ -376,47 +239,11 @@ kolibri-source (0.7.1-0ubuntu1) trusty; urgency=medium
 
  -- Benjamin Bach <benjamin@learningequality.org>  Fri, 02 Feb 2018 16:37:57 +0100
 
-kolibri-source (0.7.1~b1.dev0+git.13.gf1d43ed-0ubuntu2) trusty; urgency=medium
-
-  * Quilt patches for removing Python 2 syntax
-
- -- Benjamin Bach <benjamin@learningequality.org>  Fri, 02 Feb 2018 14:48:55 +0100
-
-kolibri-source (0.7.1~b1.dev0+git.13.gf1d43ed-0ubuntu1) trusty; urgency=medium
-
-  * New upstream release
-
- -- Benjamin Bach <benjamin@learningequality.org>  Fri, 02 Feb 2018 02:49:25 +0100
-
-kolibri-source (0.7.1~b1.dev0+git.12.g2a8fe31-0ubuntu1) trusty; urgency=medium
-
-  * New upstream release
-
- -- Benjamin Bach <benjamin@learningequality.org>  Fri, 02 Feb 2018 00:10:47 +0100
-
-kolibri-source (0.7.1~b1.dev0+git.10.gb0f4ff4-0ubuntu1) trusty; urgency=medium
-
-  * New upstream release
-
- -- Benjamin Bach <benjamin@learningequality.org>  Thu, 01 Feb 2018 00:27:18 +0100
-
-kolibri-source (0.7.1~b1-0ubuntu1) trusty; urgency=medium
-
-  * New upstream release
-
- -- Benjamin Bach <benjamin@learningequality.org>  Sun, 28 Jan 2018 23:02:20 +0100
-
 kolibri-source (0.7.0-0ubuntu1) xenial; urgency=medium
 
   * New upstream release
 
  -- Benjamin Bach <benjamin@learningequality.org>  Mon, 11 Dec 2017 17:34:50 +0100
-
-kolibri-source (0.7.0~beta5-0ubuntu1) xenial; urgency=medium
-
-  * New upstream release
-
- -- Benjamin Bach <benjamin@learningequality.org>  Mon, 04 Dec 2017 16:27:05 +0100
 
 kolibri-source (0.6.0-0ubuntu4) xenial; urgency=medium
 


### PR DESCRIPTION
Added the changelog entry for Kolibri 0.12.8.
Remove the changelog entries for betas that were only published to `kolibri-proposed` PPA. Instead of removing all of them, I merged the descriptions of them into their stable versions, as suggested by @benjaoming 