### PR TITLE
Bumping to 0.12.8-ubuntu2: Documentation of /etc/kolibri and changes to how environment is loaded

### DIFF
--- a/debian/README.etc
+++ b/debian/README.etc
@@ -21,7 +21,7 @@ file, located at `$KOLIBRI_HOME/options.ini`. By default, `$KOLIBRI_HOME` is
 If you are unsure which `$KOLIBRI_HOME` is defined for your Kolibri instance,
 this command will print it:
 
-  sudo su -l `cat /etc/kolibri/username` -c "kolibri manage shell -c 'import os; print(\"KOLIBRI_HOME is: {}\".format(os.environ[\"KOLIBRI_HOME\"]))'"
+  sudo su -l `cat /etc/kolibri/username` -c "source /etc/default/kolibri && kolibri manage shell -c 'import os; print(\"KOLIBRI_HOME is: {}\".format(os.environ[\"KOLIBRI_HOME\"]))'"
 
 
 ## Configuring the system service

--- a/debian/README.etc
+++ b/debian/README.etc
@@ -1,0 +1,17 @@
+Configuring the Kolibri Debian package:
+
+Kolibri is normally configured in its own environment, for instance in
+its main configuration file `~/.kolibri/options.ini` or through command
+line options such as `kolibri start --port=1234`.
+
+If you want Kolibri to be configured in its external environment, you can
+set a number of environment variables.
+
+The prefered way to define them is to add your own file in
+`/etc/kolibri/conf.d/<MY_CONFIGURATION>.conf`, where you can choose any
+file name and add as many configurations as you like. They will be loaded
+in alphabetical order.
+
+In these files, you can set the options defined in
+`/etc/kolibri/daemon.conf`. This configuration file is the final one
+that will be loaded.

--- a/debian/README.etc
+++ b/debian/README.etc
@@ -1,27 +1,53 @@
 # Configuring Kolibri
 
-Kolibri is normally configured using the `options.ini` config file, located
-at `$KOLIBRI_HOME/options.ini`. By default, `$KOLIBRI_HOME` is `~/.kolibri`.
+This Debian package runs Kolibri as a system service containing the kolibri
+runtime instance. The runtime process and its data is owned by a defined user
+account. The name of this user account is configured in `/etc/kolibri/username`.
 
-For more information, see:
-https://kolibri.readthedocs.io/en/latest/advanced.html
+Kolibri is intended to be controlled through the system service interface, for
+instance:
 
-If you would like to change the location of `$KOLIBRI_HOME`, you add a file
+  # systemd (default on Ubuntu 16.04+ and Debian Jessie, Stretch, Buster+)
+  sudo systemctl start/stop/restart kolibri
+  # sys-v-init (Other systems, Devuan)
+  sudo service kolibri start/stop/restart
+
+The local kolibri instance can be configured using the `options.ini` config
+file, located at `$KOLIBRI_HOME/options.ini`. By default, `$KOLIBRI_HOME` is
+`~/.kolibri`. For more information, see:
+
+  https://kolibri.readthedocs.io/en/latest/advanced.html
+
+If you are unsure which `$KOLIBRI_HOME` is defined for your Kolibri instance,
+this command will print it:
+
+  sudo su -l `cat /etc/kolibri/username` -c "kolibri manage shell -c 'import os; print(\"KOLIBRI_HOME is: {}\".format(os.environ[\"KOLIBRI_HOME\"]))'"
+
+
+## Configuring the system service
+
+If you would like to change the location of `$KOLIBRI_HOME`, you can add a file
 `/etc/kolibri/conf.d/kolibri_home.conf` with the contents:
 
-KOLIBRI_HOME=/location/of/your/choice
+  KOLIBRI_HOME=/location/of/your/choice
 
-Note that if you only want to change where content is stored, you can do that
+Tip: If you only want to change where content is stored, you can do that
 using the Kolibri `movedirectory` command:
 
-kolibri manage content movedirectory <destination>
+  # Remember to change to the configured system service user account firstly
+  su -l `cat /etc/kolibri/username`
 
-Alternatively, you can configure Kolibri using environment variables rather than
+  # Move current content folder to <destination>
+  kolibri manage content movedirectory <destination>
+
+You can configure Kolibri using environment variables rather than
 `options.ini`. Any option can be configured in conf.d files by prefixing the
 option name with "KOLIBRI_". For example, HTTP_PORT can be configured as
 
-KOLIBRI_HTTP_PORT=1234
+  KOLIBRI_HTTP_PORT=1234
 
-Files will be loaded in alphabetical order. For more examples, see the file
-`/etc/kolibri/daemon.conf`. This configuration file is the final one that
-will be loaded.
+Files in `/etc/kolibri/conf.d/<filename>.conf` will be loaded in alphabetical
+order. For more examples, see the file `/etc/kolibri/daemon.conf`.
+
+The `/etc/kolibri/daemon.conf` configuration file is the final one that will be
+loaded.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,7 +1,7 @@
 kolibri-source (0.12.8-0ubuntu2) trusty; urgency=medium
 
   * Removing unnecessary DJANGO_SETTINGS_MODULE default from /etc/default/kolibri
-  * Replacing export statements in /etc/default/kolibri with -o allexports
+  * Replacing export statements in /etc/default/kolibri with -o allexport
   * Adding /etc/kolibri/README
 
  -- Benjamin Bach <benjamin@learningequality.org>  Mon, 14 Oct 2019 10:18:24 +0200

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,7 @@
 kolibri-source (0.12.8-0ubuntu2) trusty; urgency=medium
 
+  * Removing unnecessary DJANGO_SETTINGS_MODULE default from /etc/default/kolibri
+  * Replacing export statements in /etc/default/kolibri with -o allexports
   * Adding /etc/kolibri/README
 
  -- Benjamin Bach <benjamin@learningequality.org>  Mon, 14 Oct 2019 10:18:24 +0200

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kolibri-source (0.12.8-0ubuntu2) trusty; urgency=medium
+
+  * Adding /etc/kolibri/README
+
+ -- Benjamin Bach <benjamin@learningequality.org>  Mon, 14 Oct 2019 10:18:24 +0200
+
 kolibri-source (0.12.8-0ubuntu1) trusty; urgency=medium
 
   * Kolibri v0.12.8 is released! Read the changes here: https://github.com/learningequality/kolibri/blob/v0.12.8/CHANGELOG.md#0128

--- a/debian/rules
+++ b/debian/rules
@@ -30,6 +30,7 @@ override_dh_auto_install:
 	# dh_installman
 	install -D -m0755 debian/startup/kolibri.init $(CURDIR)/debian/kolibri/etc/init.d/kolibri
 	install -D -m0644 debian/startup/kolibri.default $(CURDIR)/debian/kolibri/etc/default/kolibri
+	install -D -m0644 debian/README.etc $(CURDIR)/debian/kolibri/etc/kolibri/README
 	install -D -m0644 debian/startup/kolibri.service $(CURDIR)/debian/kolibri/lib/systemd/system/kolibri.service
 	# remove sentry_sdk files depending on Python >= 3.5:
 	rm -f $(CURDIR)/debian/kolibri/usr/lib/python3/dist-packages/kolibri/dist/sentry_sdk/integrations/aiohttp.py

--- a/debian/startup/kolibri.default
+++ b/debian/startup/kolibri.default
@@ -2,6 +2,10 @@
 # Sets the environment for the Kolibri system service
 # Do not change this script!
 #
+# This script must always be invoked with set -o allexport
+# Ref:
+# https://github.com/learningequality/kolibri-installer-debian/issues/84
+#
 # To configure the system service, please either
 
 # 1) Edit /etc/kolibri/daemon.conf
@@ -54,30 +58,3 @@ if [ -e /etc/kolibri/daemon.conf ]
 then
   . /etc/kolibri/daemon.conf
 fi
-
-# Finally, to ensure that they are available to subprocesses, export them
-# This has been a problem in Ubuntu 14.04 despite the use of `su -p`
-# Will be investigated in 0.8.x when setting a path relative to "~" is
-# supported.
-export KOLIBRI_USER
-export KOLIBRI_COMMAND
-export DJANGO_SETTINGS_MODULE
-export KOLIBRI_HOME
-
-# Other env vars that we don't define by default, but because of issues
-# propagating environment in Ubuntu 14.04, we are exporting them for now
-export KOLIBRI_LISTEN_PORT # This is deprecated
-export KOLIBRI_HTTP_PORT # Use this
-export KOLIBRI_DATABASE_ENGINE
-export KOLIBRI_DATABASE_NAME
-export KOLIBRI_DATABASE_PASSWORD
-export KOLIBRI_DATABASE_USER
-export KOLIBRI_DATABASE_HOST
-export KOLIBRI_DATABASE_PORT
-export KOLIBRI_CHERRYPY_THREAD_POOL
-export KOLIBRI_CHERRYPY_SOCKET_TIMEOUT
-export KOLIBRI_CHERRYPY_QUEUE_SIZE
-export KOLIBRI_CHERRYPY_QUEUE_TIMEOUT
-export KOLIBRI_CONTENT_DIR
-export KOLIBRI_CENTRAL_CONTENT_BASE_URL
-export KOLIBRI_RUN_MODE

--- a/debian/startup/kolibri.default
+++ b/debian/startup/kolibri.default
@@ -13,6 +13,10 @@
 #    .conf scripts are loaded in alphanumeric order
 ########################################################
 
+# This is used in order for calling shells to  read the environment defined by
+# the debian environment
+set -o allexport
+
 # Set the default values
 
 if [ -f /etc/kolibri/username ]
@@ -58,3 +62,6 @@ if [ -e /etc/kolibri/daemon.conf ]
 then
   . /etc/kolibri/daemon.conf
 fi
+
+# Switch off the allexport behavior
+set -o allexport

--- a/debian/startup/kolibri.default
+++ b/debian/startup/kolibri.default
@@ -24,7 +24,15 @@ fi
 
 KOLIBRI_HOME="$(getent passwd $KOLIBRI_USER | awk -F ':' '{print $6}')/.kolibri"
 KOLIBRI_COMMAND="kolibri"
-DJANGO_SETTINGS_MODULE="kolibri.deployment.default.settings.base"
+
+# Additional environment variables could be defined here, but be careful
+# not to define the environment for the sake of taking control over defaults,
+# as the Debian package may be used to package other source distributions
+# of Kolibri.
+# Ref:
+# https://github.com/learningequality/kolibri-installer-debian/issues/84
+# Removed:
+# DJANGO_SETTINGS_MODULE="kolibri.deployment.default.settings.base"
 
 # Load conf.d directory
 

--- a/debian/startup/kolibri.init
+++ b/debian/startup/kolibri.init
@@ -25,7 +25,9 @@ PATH=/bin:/usr/bin:/sbin:/usr/sbin
 
 . /lib/lsb/init-functions
 
+set -o allexport
 . /etc/default/kolibri
+set +o allexport
 
 # We wanted this pattern, but it doesn't work on Ubuntu 14.04
 # because $HOME is unavailable when preserving the env with -p.


### PR DESCRIPTION
This doesn't solve everything but is a nice additional help for people wondering about how to configure Kolibri when deploying the debian-based installer.

Fixes https://github.com/learningequality/kolibri-installer-debian/issues/84