### PR TITLE
Replacing su with runuser

### DIFF
--- a/debian/startup/kolibri.init
+++ b/debian/startup/kolibri.init
@@ -46,8 +46,8 @@ fi
 
 case "$1" in
   start)
-    # run ka-lite as another user, the one who generated this file
-    su $KOLIBRI_USER -c "$KOLIBRI_COMMAND start"
+    # run kolibri as another user, the one who generated this file
+    /sbin/runuser $KOLIBRI_USER -c "$KOLIBRI_COMMAND start"
     ;;
   stop)
     su $KOLIBRI_USER -c "$KOLIBRI_COMMAND stop"

--- a/debian/startup/kolibri.init
+++ b/debian/startup/kolibri.init
@@ -50,13 +50,13 @@ case "$1" in
     /sbin/runuser $KOLIBRI_USER -c "$KOLIBRI_COMMAND start"
     ;;
   stop)
-    su $KOLIBRI_USER -c "$KOLIBRI_COMMAND stop"
+    /sbin/runuser $KOLIBRI_USER -c "$KOLIBRI_COMMAND stop"
     ;;
   restart)
-    su $KOLIBRI_USER -c "$KOLIBRI_COMMAND restart"
+    /sbin/runuser $KOLIBRI_USER -c "$KOLIBRI_COMMAND restart"
     ;;
   status)
-    su $KOLIBRI_USER -c "$KOLIBRI_COMMAND status"
+    /sbin/runuser $KOLIBRI_USER -c "$KOLIBRI_COMMAND status"
     ;;
   *)
     log_success_msg "Usage: /etc/init.d/kolibri {start|stop|restart|status}"


### PR DESCRIPTION
Switched the command that starts Kolibri from su to /sbin/runuser to maintain systemd control over Kolibri and avoid the default 90s timeout upon shutdown as discussed in https://github.com/learningequality/kolibri-installer-debian/issues/90