### PR TITLE
Fix systemd shutdown, implement "restart", add back Trusty support

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -4,6 +4,12 @@ kolibri-source (0.13.2-0ubuntu1) bionic; urgency=medium
 
  -- Lingyi Wang <lingyi@learningequality.org>  Thu, 16 Apr 2020 18:22:55 -0400
 
+kolibri-source (0.13.1-0ubuntu2) trusty; urgency=medium
+
+  * Use runuser on Ubuntu 16.04+ to fix systemd issue #90
+
+ -- Benjamin Bach <benjamin@learningequality.org>  Tue, 14 Apr 2020 12:18:15 +0200
+
 kolibri-source (0.13.1-0ubuntu1) bionic; urgency=medium
 
   * Kolibri v0.13.1 is released! Read the changes here: https://github.com/learningequality/kolibri/blob/v0.13.1/CHANGELOG.md#0131

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,14 +1,20 @@
+kolibri-source (0.13.2-0ubuntu2) bionic; urgency=medium
+
+  * Use runuser on Ubuntu 16.04+ to fix systemd issue #90
+
+ -- Benjamin Bach <benjamin@learningequality.org>  Tue, 14 Apr 2020 12:18:15 +0200
+
 kolibri-source (0.13.2-0ubuntu1) bionic; urgency=medium
 
   * Kolibri v0.13.2 is released! Read the changes here: https://github.com/learningequality/kolibri/blob/v0.13.2/CHANGELOG.md#0132
 
  -- Lingyi Wang <lingyi@learningequality.org>  Thu, 16 Apr 2020 18:22:55 -0400
 
-kolibri-source (0.13.1-0ubuntu2) trusty; urgency=medium
+kolibri-source (0.13.2~beta1-0ubuntu1) bionic; urgency=medium
 
-  * Use runuser on Ubuntu 16.04+ to fix systemd issue #90
+  * New upstream beta release
 
- -- Benjamin Bach <benjamin@learningequality.org>  Tue, 14 Apr 2020 12:18:15 +0200
+ -- Lingyi Wang <lingyi@learningequality.org>  Wed, 11 Mar 2020 15:42:02 -0400
 
 kolibri-source (0.13.1-0ubuntu1) bionic; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kolibri-source (0.13.2-0ubuntu4) trusty; urgency=medium
+
+  * Restore "restart" system service command
+
+ -- Benjamin Bach <benjamin@learningequality.org>  Tue, 21 Apr 2020 12:12:32 +0200
+
 kolibri-source (0.13.2-0ubuntu3) trusty; urgency=medium
 
   * Restoring 14.04 support: Changing dist target to trusty

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kolibri-source (0.13.2-0ubuntu3) trusty; urgency=medium
+
+  * Restoring 14.04 support: Changing dist target to trusty
+
+ -- Benjamin Bach <benjamin@learningequality.org>  Mon, 20 Apr 2020 17:43:48 +0200
+
 kolibri-source (0.13.2-0ubuntu2) bionic; urgency=medium
 
   * Use runuser on Ubuntu 16.04+ to fix systemd issue #90

--- a/debian/startup/kolibri.init
+++ b/debian/startup/kolibri.init
@@ -25,6 +25,17 @@ PATH=/bin:/usr/bin:/sbin:/usr/sbin
 
 . /lib/lsb/init-functions
 
+# Prefer runuser over su
+# See: https://github.com/learningequality/kolibri-installer-debian/issues/90
+# Check if runuser exists - it doesn't on 14.04
+if which runuser > /dev/null
+then
+  SU_COMMAND="runuser"
+else
+  SU_COMMAND="su"
+fi
+
+
 set -o allexport
 . /etc/default/kolibri
 set +o allexport
@@ -47,16 +58,16 @@ fi
 case "$1" in
   start)
     # run kolibri as another user, the one who generated this file
-    /sbin/runuser $KOLIBRI_USER -c "$KOLIBRI_COMMAND start"
+    $SU_COMMAND $KOLIBRI_USER -c "$KOLIBRI_COMMAND start"
     ;;
   stop)
-    /sbin/runuser $KOLIBRI_USER -c "$KOLIBRI_COMMAND stop"
+    $SU_COMMAND $KOLIBRI_USER -c "$KOLIBRI_COMMAND stop"
     ;;
   restart)
-    /sbin/runuser $KOLIBRI_USER -c "$KOLIBRI_COMMAND restart"
+    $SU_COMMAND $KOLIBRI_USER -c "$KOLIBRI_COMMAND restart"
     ;;
   status)
-    /sbin/runuser $KOLIBRI_USER -c "$KOLIBRI_COMMAND status"
+    $SU_COMMAND $KOLIBRI_USER -c "$KOLIBRI_COMMAND status"
     ;;
   *)
     log_success_msg "Usage: /etc/init.d/kolibri {start|stop|restart|status}"

--- a/debian/startup/kolibri.init
+++ b/debian/startup/kolibri.init
@@ -64,7 +64,8 @@ case "$1" in
     $SU_COMMAND $KOLIBRI_USER -c "$KOLIBRI_COMMAND stop"
     ;;
   restart)
-    $SU_COMMAND $KOLIBRI_USER -c "$KOLIBRI_COMMAND restart"
+    $SU_COMMAND $KOLIBRI_USER -c "$KOLIBRI_COMMAND stop"
+    $SU_COMMAND $KOLIBRI_USER -c "$KOLIBRI_COMMAND start"
     ;;
   status)
     $SU_COMMAND $KOLIBRI_USER -c "$KOLIBRI_COMMAND status"

--- a/ppa-copy-packages.py
+++ b/ppa-copy-packages.py
@@ -29,7 +29,7 @@ PPA_OWNER = 'learningequality'
 PPA_NAME = 'kolibri-proposed'
 PACKAGE_WHITELIST = ['kolibri-source']
 
-SOURCE_SERIES = 'trusty'
+SOURCE_SERIES = 'bionic'
 TARGET_SERIESES = ['trusty', 'xenial', 'bionic', 'disco', 'eoan']
 POCKET = 'Release'
 

--- a/ppa-copy-packages.py
+++ b/ppa-copy-packages.py
@@ -29,7 +29,7 @@ PPA_OWNER = 'learningequality'
 PPA_NAME = 'kolibri-proposed'
 PACKAGE_WHITELIST = ['kolibri-source']
 
-SOURCE_SERIES = 'bionic'
+SOURCE_SERIES = 'trusty'
 TARGET_SERIESES = ['trusty', 'xenial', 'bionic', 'disco', 'eoan']
 POCKET = 'Release'
 


### PR DESCRIPTION
Follow-up on #92

Released on kolibri-proposed

* "su" on Ubuntu 14.04, "runuser" for the others
* Restore Trusty support
* Fix `systemctl restart kolibri` and `service kolibri restart`