### PR TITLE
Adds a min version for Recommends: python-cryptography

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -31,7 +31,7 @@ Architecture: all
 Depends: python3 (>= 3.4),
          python3-pkg-resources,
          adduser
-Recommends: python3-cryptography
+Recommends: python3-cryptography (>= 1.2.3)
 Description: The offline app for universal education
  An educational platform for learners of all ages.
  .


### PR DESCRIPTION
Since #11 we have been installing python3-cryptography automatically through `Recommends` (a soft dependency), but this also automatically breaks Kolibri on systems where the version is too old

Fixes #30 