### PR TITLE
Add example for switching on debug log level (arrives in 0.14)

### DIFF
--- a/debian/kolibri.scripts-common
+++ b/debian/kolibri.scripts-common
@@ -107,6 +107,7 @@ default_user_conf() {
 # KOLIBRI_HOME="~/.kolibri"
 # KOLIBRI_LISTEN_PORT="8080"
 # KOLIBRI_COMMAND="kolibri"
+# KOLIBRI_DEBUG=1  # Switches on debug log level (noisy!)
 # DJANGO_SETTINGS_MODULE="kolibri.deployment.default.settings.base"
 
 EOF


### PR DESCRIPTION
Adds an example in the commented out section of the `/etc/kolibri/daemon.conf` file

Closes #88

Merging this before 0.14 is released is fairly harmless.. but it won't have an effect before 0.14