### PR TITLE
Remove bundled Python 2.7 and Windows C extensions

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kolibri-source (0.13.2-0ubuntu5) trusty; urgency=medium
+
+  * Reduce package size: Remove unused binary code
+
+ -- Benjamin Bach <benjamin@learningequality.org>  Mon, 11 May 2020 14:09:05 +0200
+
 kolibri-source (0.13.2-0ubuntu4) trusty; urgency=medium
 
   * Restore "restart" system service command

--- a/debian/rules
+++ b/debian/rules
@@ -38,6 +38,9 @@ override_dh_auto_install:
 	rm -f $(CURDIR)/debian/kolibri/usr/lib/python3/dist-packages/kolibri/dist/sentry_sdk/integrations/tornado.py
 	# remove py2only:
 	rm -Rf $(CURDIR)/debian/kolibri/usr/lib/python3/dist-packages/kolibri/dist/py2only
+	# remove C extensions for other platforms:
+	rm -Rf $(CURDIR)/debian/kolibri/usr/lib/python3/dist-packages/kolibri/dist/cext/cp27
+	find $(CURDIR)/debian/kolibri/usr/lib/python3/dist-packages/kolibri/dist/cext/ -path '*/cp3*/Windows' -exec 'rm -rf {}' \;
 
 ifeq ($(filter stage1,$(DEB_BUILD_PROFILES)),)
 override_dh_installdeb:


### PR DESCRIPTION
Reduces the package size by 7 MB.

TBH, I had hoped it would reduce the package size more.