### PR TITLE
Adding block step before debian tests 

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -12,7 +12,9 @@ steps:
     env:
       DOCKER_IMAGES: ubuntu:focal
     command: .buildkite/test.sh
-    
+
+  - block: "Test :debian:?"
+  
   - label: Test ubuntu:bionic
     env:
       DOCKER_IMAGES: ubuntu:bionic


### PR DESCRIPTION
Because the trusty tests break kolibri pipeline, even for RCs