### PR TITLE
Small rules tweak

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kolibri-source (0.15.1-0ubuntu1) bionic; urgency=medium
+
+  * New upstream release
+
+ -- José L. Redrejo Rodríguez <jredrejo@debian.org>  Wed, 16 Feb 2022 19:21:24 +0100
+
 kolibri-source (0.15.0-0ubuntu1) bionic; urgency=high
 
   * New upstream release

--- a/debian/rules
+++ b/debian/rules
@@ -32,10 +32,6 @@ override_dh_auto_install:
 	install -D -m0644 debian/startup/kolibri.default $(CURDIR)/debian/kolibri/etc/default/kolibri
 	install -D -m0644 debian/README.etc $(CURDIR)/debian/kolibri/etc/kolibri/README
 	install -D -m0644 debian/startup/kolibri.service $(CURDIR)/debian/kolibri/lib/systemd/system/kolibri.service
-	# remove sentry_sdk files depending on Python >= 3.5:
-	rm -f $(CURDIR)/debian/kolibri/usr/lib/python3/dist-packages/kolibri/dist/sentry_sdk/integrations/aiohttp.py
-	rm -f $(CURDIR)/debian/kolibri/usr/lib/python3/dist-packages/kolibri/dist/sentry_sdk/integrations/sanic.py
-	rm -f $(CURDIR)/debian/kolibri/usr/lib/python3/dist-packages/kolibri/dist/sentry_sdk/integrations/tornado.py
 	# remove py2only:
 	rm -Rf $(CURDIR)/debian/kolibri/usr/lib/python3/dist-packages/kolibri/dist/py2only
 	# remove C extensions for other platforms:


### PR DESCRIPTION
- Changelog updated to 0.15.1
- Removed unneeded sentry commands in debian/rules

Closes: #110 