### PR TITLE
Adds a conflict with newest versions of python markdown

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,15 @@
+kolibri-source (0.15.6-0ubuntu2) bionic; urgency=medium
+
+  * Added conflict with python3-markdown>=3.4 due to DRF restrictions
+
+ -- José L. Redrejo Rodríguez <jredrejo@debian.org>  Thu, 18 Aug 2022 20:15:26 +0200
+
+kolibri-source (0.15.6-0ubuntu1) bionic; urgency=medium
+
+  * New upstream release
+
+ -- José L. Redrejo Rodríguez <jredrejo@debian.org>  Tue, 19 Jul 2022 11:42:21 +0200
+
 kolibri-source (0.15.5-0ubuntu1) bionic; urgency=medium
 
   * New upstream release

--- a/debian/control
+++ b/debian/control
@@ -32,6 +32,7 @@ Depends: python3 (>= 3.4),
          python3-pkg-resources,
          adduser
 Recommends: python3-cryptography (>= 1.2.3)
+Conflicts: python3-markdown (>= 3.4.1)
 Description: The offline app for universal education
  An educational platform for learners of all ages.
  .


### PR DESCRIPTION
Adds a conflict in the Debian package with newest versions of python Markdown to avoid problems when installing kolibri in new systems
Relates: https://github.com/learningequality/kolibri/issues/9583
Closes: #112 