### PR TITLE
Honor (don't ignore) /etc/kolibri/username when installing Kolibri — putting an end to 2 contradictory KOLIBRI_USER settings

### DIFF
--- a/debian/kolibri.scripts-common
+++ b/debian/kolibri.scripts-common
@@ -346,15 +346,21 @@ kolibri_debconf_set_defaults()
         db_fset kolibri/pre-010-upgrade-system-user seen true
     fi
 
-    if [ "$USER_SEEN" == "false" ]
+    if [ -s /etc/kolibri/username ]    # Test that file exists with non-zero size
     then
-        # DESKTOP_USER=`getent passwd | awk -F: '$3 >= 1000 && $3 < 2000 {print $1}'`
-        DESKTOP_USER=`getent passwd | cut -d: -f1,3 | egrep ':[0-9]{4}$' | cut -d: -f1 | head -1`
-        if ! [ "$DESKTOP_USER" == "" ]
+        KOLIBRI_USER=$(cat /etc/kolibri/username)
+        db_set kolibri/user "$KOLIBRI_USER"
+    else
+        if [ "$USER_SEEN" == "false" ]
         then
-            # Set default to the user running the installation
-            db_set kolibri/user "$DESKTOP_USER"
-            db_fset kolibri/user seen false
+            # DESKTOP_USER=`getent passwd | awk -F: '$3 >= 1000 && $3 < 2000 {print $1}'`
+            DESKTOP_USER=`getent passwd | cut -d: -f1,3 | egrep ':[0-9]{4}$' | cut -d: -f1 | head -1`
+            if ! [ "$DESKTOP_USER" == "" ]
+            then
+                # Set default to the user running the installation
+                db_set kolibri/user "$DESKTOP_USER"
+                db_fset kolibri/user seen false
+            fi
         fi
     fi
 


### PR DESCRIPTION
This PR fixes the worst of several problems described on Sept 9, 2022 here:

- #115

Thanks @jredrejo @benjaoming @radinamatic for reviewing when you have time.

Recap: This fixes the serious problem of Kolibri's Debian/Ubuntu (apt / .deb) installer ignoring `/etc/kolibri/username`

Which results in Kolibri's 2 permanently contradictory settings (i.e. 2 contradictory values) for KOLIBRI_USER — i.e. in these 2 places:

- /var/cache/debconf/config.dat
- /etc/kolibri/username

Not pretty!  So a month or so later, typically the first time a school apt upgrades, Kolibri's new Debian package erroneously tries to force the school (and all https://internet-in-a-box.org schools, if they are online and run `apt update` etc) to try to change KOLIBRI_USER:

```
┌─────────────────────────────────────────────────────────┤ Kolibri configuration ├─────────────────────────────────────────────────────────┐
│ The default is to choose your preferred desktop user account, for instance to ensure access to importing data from external USB devices.  │
│                                                                                                                                           │
│ Entering a username that doesn't exist will create a new system user with home directory /var/<username>.                                 │
│                                                                                                                                           │
│ Which user account should own the Kolibri server?                                                                                         │
│                                                                                                                                           │
│ ubuntu   <<<< WRONG!!! (user "kolibri" is already specified at /etc/kolibri/username)   _________________________________________________ │
│                                                                                                                                           │
│                                                                  <Ok>                                                                     │
│                                                                                                                                           │
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
```

Why does this happen every single time a school first upgrades Kolibri?  One can only assume that Ansible (Linux automation, that [arranges](https://github.com/iiab/iiab/blob/master/roles/kolibri/tasks/install.yml) all Internet-in-a-Box installs) runs something like:

```
export DEBIAN_FRONTEND=noninteractive
apt install kolibri
```

So what happens is that Kolibri's Ubuntu/Debian package (1) Encodes the very misleading (erroneous, desktop-like) KOLIBRI_USER into /var/cache/debconf/config.dat (2) Effectively deferring its 3-to-5 debconf screens asking for things like KOLIBRI_USER until 1 or 2 months later, into the hands of the wrong person, after everything's installed in a school (3) Leading to serious confusion + conflicting KOLIBRI_USER settings down the road, that nobody wants 😖

CONCLUSION: This simple PR eliminates the conflicting settings, and at least brings us a lot closer to what the doc portrays at https://kolibri.readthedocs.io/en/latest/install/ubuntu-debian.html#id2 — pasted in here:

![image](https://user-images.githubusercontent.com/2458907/227666614-53258632-c91e-4422-b27d-6baf1fd1269b.png)

STRETCH GOAL FOR LATER: Eliminating all screens during `apt upgrade` would be far-and-away better for most schools, who are simply trying to upgrade Kolibri, and do **_not_** want to change any settings, or read long-winded technical screens 🥲 (as we all strive to help schools focus on learning, **_not_** unnecessary low-level administration!)

IN SHORT, Internet-in-a-Box can easily force far cleaner behavior during Kolibri upgrades (i.e. what schools prefer) with a hacky script like the following: _(but we'd rather work with Kolibri to solve the problem properly, thoughtfully and in due course, helping everyone)_

```
#!/bin/bash

#CONFIGFILE=/var/cache/debconf/config.dat
set -e

. /usr/share/debconf/confmodule
db_fset kolibri/user seen true
db_fset kolibri/init seen true
db_fset kolibri/init-instructions seen true
```