### PR TITLE
Ensure apt indexes are updated

### DIFF
--- a/.github/workflows/build_deb.yml
+++ b/.github/workflows/build_deb.yml
@@ -51,6 +51,8 @@ jobs:
       with:
         name: ${{ inputs.tar-file-name }}
         path: build_src
+    - name: Update repository indexes
+      run: sudo apt update       
     - name: Install Debian build package dependencies
       run: sudo apt install -y devscripts debhelper dh-python python3-all python3-pytest po-debconf python3-setuptools python3-pip
     - name: Run the build


### PR DESCRIPTION
It seems using ubuntu-latest to build the package does not ensure the package index is updated. This change forces it.