### PR TITLE
Update dependabot to monthly schedule with 7-day cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,11 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "friday"
+      interval: "monthly"
       time: "00:00"
+    # Wait 7 days before proposing updates to newly released versions
+    cooldown:
+      default-days: 7
     groups:
       github:
         patterns:


### PR DESCRIPTION
- Change update interval from weekly to monthly
- Add cooldown of 7 days to avoid upgrading to freshly released versions

:robot: This was created by Claude Code. @rtibbles then reviewed the generated output, and did iterative rounds of updates before making it ready for review :robot: 