### PR TITLE
ci: install build-essential for source package build in prerelease

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -66,7 +66,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y devscripts debhelper python3-pip dput \
             dh-python python3-all python3-pytest python3-launchpadlib \
-            python3-distro-info
+            python3-distro-info build-essential po-debconf python3-setuptools
       - name: Install Python dependencies
         run: pip install .
       - name: Extract version


### PR DESCRIPTION
## Summary

The new "Pre-release to kolibri-proposed PPA" workflow ([failing run](https://github.com/learningequality/kolibri-installer-debian/actions/runs/26472990875/job/77951148828)) aborted at the source-package build with:

```
dpkg-checkbuilddeps: error: Unmet build dependencies: build-essential:native
```

`dpkg-buildpackage -S` runs `dpkg-checkbuilddeps` even for source-only builds, and dpkg injects an implicit `build-essential:native` requirement regardless of `debian/control` — so the build aborts when `build-essential` isn't installed, even though assembling a source package doesn't compile anything (Launchpad does that). The new workflow's apt install list omitted `build-essential` (plus `po-debconf` and `python3-setuptools`) that the existing `build_deb.yml` already installs. Added them for parity.

## References

- Introduced by #160 (`automate-ppa-releases`)
- Failing run: https://github.com/learningequality/kolibri-installer-debian/actions/runs/26472990875/job/77951148828

## Reviewer guidance

The real verification is a green run of the "Pre-release to kolibri-proposed PPA" workflow — specifically the "Build and upload source package" step getting past `dpkg-checkbuilddeps`. Worth confirming the added package list now matches `build_deb.yml`'s (the working binary build).

## AI usage

I used Claude Code to diagnose the CI failure — it traced the error to the implicit `build-essential:native` dependency that `dpkg-checkbuilddeps` adds, compared the new workflow's apt list against the working `build_deb.yml`, and applied the one-line fix. I reviewed the diagnosis and confirmed the omission against both workflows.