### PR TITLE
fix: repair PPA release automation (maintainer, binary-name lookup, prerelease signing)

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -90,7 +90,6 @@ jobs:
         run: |
           set +e
           python3 scripts/launchpad_copy.py check-source \
-            --package kolibri-source \
             --version "${{ steps.version.outputs.version }}"
           rc=$?
           set -e

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -155,7 +155,9 @@ jobs:
           # No --series: discover the series the source was actually uploaded
           # to (the current LTS), rather than assuming the runner's own series.
           python3 scripts/launchpad_copy.py wait-for-published \
-            --version "${{ needs.build_source_and_upload.outputs.version }}"
+            --version "${{ needs.build_source_and_upload.outputs.version }}" \
+            --timeout 14400 \
+            --interval 600
       - name: Cleanup Launchpad credentials
         if: always()
         run: rm -f /tmp/lp-creds.txt
@@ -218,7 +220,9 @@ jobs:
           LP_CREDENTIALS_FILE: /tmp/lp-creds.txt
         run: |
           python3 scripts/launchpad_copy.py wait-for-published \
-            --version "${{ needs.build_source_and_upload.outputs.version }}"
+            --version "${{ needs.build_source_and_upload.outputs.version }}" \
+            --timeout 14400 \
+            --interval 600
       - name: Cleanup Launchpad credentials
         if: always()
         run: rm -f /tmp/lp-creds.txt

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -6,6 +6,10 @@ on:
       tar-url:
         description: 'URL for Kolibri tar file'
         required: true
+      ubuntu-revision:
+        description: 'Debian packaging revision (the N in -0ubuntuN); bump to re-release the same version after a packaging fix'
+        required: false
+        default: '1'
   workflow_call:
     inputs:
       tar-file-name:
@@ -18,6 +22,11 @@ on:
         description: 'A ref for this workflow to check out its own repo'
         required: false
         type: string
+      ubuntu-revision:
+        description: 'Debian packaging revision (the N in -0ubuntuN)'
+        required: false
+        type: string
+        default: '1'
     outputs:
       version:
         description: "Full Debian version string (e.g. 0.19.3-0ubuntu1)"
@@ -71,12 +80,14 @@ jobs:
         run: pip install .
       - name: Extract version
         id: version
+        env:
+          UBUNTU_REVISION: ${{ inputs.ubuntu-revision }}
         run: |
           make dist/VERSION
           VERSION=$(cat dist/VERSION)
           # Convert to Debian version format (match version_to_debian in generate_changelog.py)
           DEB_VERSION=$(echo "$VERSION" | sed 's/-\(alpha\|beta\|rc\)/~\1/g' | sed 's/\.dev/~dev/g')
-          FULL_VERSION="${DEB_VERSION}-0ubuntu1"
+          FULL_VERSION="${DEB_VERSION}-0ubuntu${UBUNTU_REVISION}"
           echo "version=$FULL_VERSION" >> "$GITHUB_OUTPUT"
           echo "Package version: $FULL_VERSION"
       - name: Write Launchpad credentials
@@ -111,6 +122,7 @@ jobs:
         if: steps.check_source.outputs.already_uploaded != 'true'
         env:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          UBUNTU_REVISION: ${{ inputs.ubuntu-revision }}
         run: make commit-new-release
       - name: Cleanup credentials
         if: always()

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -152,10 +152,10 @@ jobs:
         env:
           LP_CREDENTIALS_FILE: /tmp/lp-creds.txt
         run: |
-          SERIES=$(lsb_release -cs)
+          # No --series: discover the series the source was actually uploaded
+          # to (the current LTS), rather than assuming the runner's own series.
           python3 scripts/launchpad_copy.py wait-for-published \
-            --version "${{ needs.build_source_and_upload.outputs.version }}" \
-            --series "$SERIES"
+            --version "${{ needs.build_source_and_upload.outputs.version }}"
       - name: Cleanup Launchpad credentials
         if: always()
         run: rm -f /tmp/lp-creds.txt

--- a/.github/workflows/release_ppa.yml
+++ b/.github/workflows/release_ppa.yml
@@ -65,7 +65,9 @@ jobs:
         run: |
           python3 scripts/launchpad_copy.py wait-for-published \
             --version "${{ inputs.version }}" \
-            --ppa kolibri
+            --ppa kolibri \
+            --timeout 14400 \
+            --interval 600
       - name: Cleanup Launchpad credentials
         if: always()
         run: rm -f /tmp/lp-creds.txt

--- a/build_tools/build.sh
+++ b/build_tools/build.sh
@@ -120,7 +120,9 @@ tar xf *orig.tar.gz
 # SOURCE_DIR=`tar --exclude="*/*" -tf *.orig.tar.gz|head -1`
 SOURCE_DIR=`ls -d kolibri*/`
 cp -r ../debian $SOURCE_DIR
-DEB_VERSION=`cat VERSION | sed -s 's/^\+\.\+\.\+\([abc]\|\.dev\)/\~\0/g'`
+# Convert to Debian version format so this matches the filename dpkg-buildpackage
+# produces from the generated changelog (version_to_debian in generate_changelog.py).
+DEB_VERSION=`cat VERSION | sed 's/-\(alpha\|beta\|rc\)/~\1/g' | sed 's/\.dev/~dev/g'`
 
 cd $SOURCE_DIR
 python3 ../../build_tools/generate_changelog.py \

--- a/build_tools/build.sh
+++ b/build_tools/build.sh
@@ -124,11 +124,16 @@ cp -r ../debian $SOURCE_DIR
 # produces from the generated changelog (version_to_debian in generate_changelog.py).
 DEB_VERSION=`cat VERSION | sed 's/-\(alpha\|beta\|rc\)/~\1/g' | sed 's/\.dev/~dev/g'`
 
+# Debian packaging revision (the N in -0ubuntuN). Bump to re-release the
+# same upstream version after a packaging-only fix.
+UBUNTU_REVISION="${UBUNTU_REVISION:-1}"
+
 cd $SOURCE_DIR
 python3 ../../build_tools/generate_changelog.py \
     --debian-changelog debian/changelog \
     --version-file ../VERSION \
-    --packaging-changelog ../../CHANGELOG
+    --packaging-changelog ../../CHANGELOG \
+    --ubuntu-revision "$UBUNTU_REVISION"
 
 # package can't be run from a virtualenv
 if [[ "$VIRTUAL_ENV" != "" ]]
@@ -140,7 +145,7 @@ fi
 if [[ "$BUILD_BINARY" -eq "0" ]]; then
     # build source package only
    dpkg-buildpackage -S  --no-sign
-   signfiles kolibri-source_$DEB_VERSION-0ubuntu1
+   signfiles kolibri-source_$DEB_VERSION-0ubuntu${UBUNTU_REVISION}
 else
     # build with unsigned source, changes and gzip compression
     dpkg-buildpackage -A -Zgzip -z3 -us -uc

--- a/build_tools/generate_changelog.py
+++ b/build_tools/generate_changelog.py
@@ -219,10 +219,15 @@ def get_current_lts_codename():
     return ubuntu.lts()
 
 
-def generate_release_entries(releases):
+def generate_release_entries(releases, ubuntu_revision=1):
     """Generate changelog entry dicts from GitHub release data.
 
     Returns list of dicts with keys: version, ubuntu_revision, text
+
+    ubuntu_revision bumps the Debian packaging revision (the N in
+    -0ubuntuN). Use > 1 to re-release the same upstream version after a
+    packaging-only fix, since a PPA permanently reserves each uploaded
+    version-revision.
     """
     distribution = get_current_lts_codename()
     entries = []
@@ -232,7 +237,7 @@ def generate_release_entries(releases):
         timestamp = github_timestamp_to_debian(release["published_at"])
         text = format_changelog_entry(
             version=version,
-            ubuntu_revision=1,
+            ubuntu_revision=ubuntu_revision,
             distribution=distribution,
             message="New upstream release",
             maintainer=MAINTAINER,
@@ -240,7 +245,7 @@ def generate_release_entries(releases):
         )
         entries.append({
             "version": version,
-            "ubuntu_revision": 1,
+            "ubuntu_revision": ubuntu_revision,
             "text": text,
         })
 
@@ -308,7 +313,7 @@ def interleave_entries(release_entries, packaging_entries):
 
 
 def generate_updated_changelog(existing_content, releases, packaging_changelog,
-                               build_version):
+                               build_version, ubuntu_revision=1):
     """Generate the full updated debian/changelog content.
 
     Combines new release entries, packaging entries, and existing content.
@@ -325,7 +330,7 @@ def generate_updated_changelog(existing_content, releases, packaging_changelog,
         return existing_content
 
     # Generate release entries
-    release_entries = generate_release_entries(new_releases)
+    release_entries = generate_release_entries(new_releases, ubuntu_revision=ubuntu_revision)
 
     # Parse packaging entries and filter to only new ones
     pkg_entries = parse_packaging_changelog(packaging_changelog)
@@ -350,7 +355,8 @@ def generate_updated_changelog(existing_content, releases, packaging_changelog,
     return new_section + "\n" + existing_content
 
 
-def main(debian_changelog_path, version_path, packaging_changelog_path):
+def main(debian_changelog_path, version_path, packaging_changelog_path,
+         ubuntu_revision=1):
     """Update debian/changelog from GitHub releases and top-level CHANGELOG."""
     with open(debian_changelog_path) as f:
         existing_content = f.read()
@@ -370,6 +376,7 @@ def main(debian_changelog_path, version_path, packaging_changelog_path):
         releases=releases,
         packaging_changelog=packaging_changelog,
         build_version=build_version,
+        ubuntu_revision=ubuntu_revision,
     )
 
     with open(debian_changelog_path, "w") as f:
@@ -394,5 +401,10 @@ if __name__ == "__main__":
         "--packaging-changelog", default="CHANGELOG",
         help="Path to top-level CHANGELOG (default: %(default)s)"
     )
+    parser.add_argument(
+        "--ubuntu-revision", type=int, default=1,
+        help="Debian packaging revision, the N in -0ubuntuN (default: %(default)s)"
+    )
     args = parser.parse_args()
-    main(args.debian_changelog, args.version_file, args.packaging_changelog)
+    main(args.debian_changelog, args.version_file, args.packaging_changelog,
+         ubuntu_revision=args.ubuntu_revision)

--- a/build_tools/generate_changelog.py
+++ b/build_tools/generate_changelog.py
@@ -77,10 +77,7 @@ def is_prerelease(version_str):
 
 
 PACKAGE_NAME = "kolibri-source"
-MAINTAINER = (
-    "Learning Equality \\(Learning Equality\\'s public signing key\\) "
-    "<accounts@learningequality.org>>"
-)
+MAINTAINER = "Learning Equality <accounts@learningequality.org>"
 
 
 def version_to_debian(version_str):

--- a/scripts/launchpad_copy.py
+++ b/scripts/launchpad_copy.py
@@ -49,7 +49,11 @@ except ImportError:
 PPA_OWNER = "learningequality"
 PROPOSED_PPA_NAME = "kolibri-proposed"
 RELEASE_PPA_NAME = "kolibri"
-PACKAGE_WHITELIST = ["kolibri-source"]
+# The source package and the single binary package it produces have
+# different names (debian/control: Source: kolibri-source / Package: kolibri).
+SOURCE_PACKAGE_NAME = "kolibri-source"
+BINARY_PACKAGE_NAME = "kolibri"
+PACKAGE_WHITELIST = [SOURCE_PACKAGE_NAME]
 POCKET = "Release"
 APP_NAME = "ppa-kolibri-source-copy-packages"
 
@@ -350,7 +354,7 @@ class LaunchpadWrapper:
         log.debug("All done")
         return result
 
-    def check_source(self, package, version, ppa_name=None):
+    def check_source(self, version, ppa_name=None):
         """Check if a source package version exists in a PPA.
 
         Returns 0 if found (already uploaded), 1 if missing, 2 on error.
@@ -359,26 +363,26 @@ class LaunchpadWrapper:
         try:
             ppa = self.get_ppa(ppa_name)
             published = ppa.getPublishedSources(
-                source_name=package,
+                source_name=SOURCE_PACKAGE_NAME,
                 version=version,
                 order_by_date=True,
             )
             active = [s for s in published if s.status not in ("Deleted", "Superseded", "Obsolete")]
         except Exception as e:
-            log.error("Error checking %s %s in %s: %s", package, version, ppa_name, e)
+            log.error("Error checking %s %s in %s: %s", SOURCE_PACKAGE_NAME, version, ppa_name, e)
             return 2
         if active:
-            log.info("%s %s already exists in %s (status: %s)", package, version, ppa_name, active[0].status)
+            log.info("%s %s already exists in %s (status: %s)", SOURCE_PACKAGE_NAME, version, ppa_name, active[0].status)
             return 0
-        log.info("%s %s not found in %s", package, version, ppa_name)
+        log.info("%s %s not found in %s", SOURCE_PACKAGE_NAME, version, ppa_name)
         return 1
 
-    def wait_for_published(self, package, version, ppa_name=None, series=None, timeout=1800, interval=60):
-        """Wait for published binaries to appear for a package.
+    def wait_for_published(self, version, ppa_name=None, series=None, timeout=1800, interval=60):
+        """Wait for published binaries to appear for the package.
 
         If series is given, waits for those specific series to have published binaries.
         If series is None, discovers all series that have a published source for this
-        package+version and waits until every one of them also has published binaries.
+        version and waits until every one of them also has published binaries.
         Returns 0 if all expected series are published, 1 on failure or timeout.
         """
         ppa_name = ppa_name or PROPOSED_PPA_NAME
@@ -388,7 +392,7 @@ class LaunchpadWrapper:
 
         log.info(
             "Waiting for %s %s to be published in %s%s...",
-            package,
+            BINARY_PACKAGE_NAME,
             version,
             ppa_name,
             " for series: %s" % ", ".join(sorted(expected)) if expected else "",
@@ -398,7 +402,7 @@ class LaunchpadWrapper:
             # If no explicit series, discover from published sources
             if expected is None:
                 sources = ppa.getPublishedSources(
-                    source_name=package,
+                    source_name=SOURCE_PACKAGE_NAME,
                     version=version,
                     order_by_date=True,
                 )
@@ -418,7 +422,7 @@ class LaunchpadWrapper:
 
             # Check published binaries
             bins = ppa.getPublishedBinaries(
-                binary_name=package,
+                binary_name=BINARY_PACKAGE_NAME,
                 version=version,
                 order_by_date=True,
             )
@@ -444,7 +448,7 @@ class LaunchpadWrapper:
             log.info("Retrying in %ds (%ds remaining)...", interval, remaining)
             time.sleep(interval)
 
-        log.error("Timeout: %s %s not published within %ds", package, version, timeout)
+        log.error("Timeout: %s %s not published within %ds", BINARY_PACKAGE_NAME, version, timeout)
         return 1
 
     def promote(self, version):
@@ -535,7 +539,6 @@ def build_parser():
         "wait-for-published",
         help="Wait for published binaries to appear for a source package.",
     )
-    wait_parser.add_argument("--package", required=True, help="Source package name.")
     wait_parser.add_argument("--version", required=True, help="Expected version string.")
     wait_parser.add_argument("--ppa", default=PROPOSED_PPA_NAME, help="PPA name to poll (default: %(default)s).")
     wait_parser.add_argument("--timeout", type=int, default=1800, help="Max wait in seconds (default: %(default)s).")
@@ -548,7 +551,6 @@ def build_parser():
         "check-source",
         help="Check if a source package version already exists in a PPA.",
     )
-    check_parser.add_argument("--package", required=True, help="Source package name.")
     check_parser.add_argument("--version", required=True, help="Expected version string.")
     check_parser.add_argument("--ppa", default=PROPOSED_PPA_NAME, help="PPA name to check (default: %(default)s).")
 
@@ -579,7 +581,6 @@ def cmd_wait_for_published(args):
     """Wait for published binaries to appear."""
     lp = LaunchpadWrapper()
     return lp.wait_for_published(
-        package=args.package,
         version=args.version,
         ppa_name=args.ppa,
         series=args.series,
@@ -592,7 +593,6 @@ def cmd_check_source(args):
     """Check if a source package version already exists in a PPA."""
     lp = LaunchpadWrapper()
     return lp.check_source(
-        package=args.package,
         version=args.version,
         ppa_name=args.ppa,
     )

--- a/scripts/launchpad_copy.py
+++ b/scripts/launchpad_copy.py
@@ -17,6 +17,7 @@ Adapted from kolibri-server's launchpad_copy.py with these changes:
 
 import argparse
 import functools
+import http.client
 import logging
 import os
 import sys
@@ -55,6 +56,19 @@ BINARY_PACKAGE_NAME = "kolibri"
 PACKAGE_WHITELIST = [SOURCE_PACKAGE_NAME]
 POCKET = "Release"
 APP_NAME = "ppa-kolibri-source-copy-packages"
+
+# Transient network failures that should be retried rather than aborting a
+# long-running poll. ssl.SSLEOFError (a subclass of OSError) is the one seen in
+# CI: across a long polling interval Launchpad drops the idle keep-alive socket,
+# and reusing the stale connection raises "EOF occurred in violation of protocol".
+TRANSIENT_ERRORS = (OSError, http.client.HTTPException)
+if httplib2 is not None:
+    TRANSIENT_ERRORS += (httplib2.HttpLib2Error,)
+
+# Per-call retry budget for transient errors: a quick reconnect-and-retry so a
+# single blip doesn't fail the release. Backoff is BACKOFF * attempt seconds.
+TRANSIENT_RETRY_ATTEMPTS = 4
+TRANSIENT_RETRY_BACKOFF = 15
 
 log = logging.getLogger(APP_NAME)
 
@@ -190,6 +204,43 @@ class LaunchpadWrapper:
         owner = self.owner
         log.debug("Getting PPA: %s...", name)
         return owner.getPPAByName(name=name)
+
+    def _drop_stale_connections(self):
+        """Discard cached HTTP sockets so the next API call reconnects.
+
+        Launchpad closes idle keep-alive connections; reusing a stale socket
+        after a long polling interval raises ssl.SSLEOFError. Clearing the
+        httplib2 connection cache forces a fresh connection on the next request.
+        Best-effort: the private attribute path may vary across launchpadlib
+        versions, so failures here are non-fatal (the retry still reconnects).
+        """
+        try:
+            self.lp._browser._connection.connections.clear()
+        except Exception:
+            pass
+
+    def _retry_transient(self, label, call):
+        """Run ``call()``, retrying transient network errors with backoff.
+
+        A single connection blip (e.g. a stale keep-alive socket raising
+        ssl.SSLEOFError between polls) should not abort the whole release wait.
+        Reconnects and retries up to TRANSIENT_RETRY_ATTEMPTS times; re-raises
+        if every attempt fails (a sustained outage should fail loudly).
+        """
+        for attempt in range(1, TRANSIENT_RETRY_ATTEMPTS + 1):
+            try:
+                return call()
+            except TRANSIENT_ERRORS as e:
+                if attempt == TRANSIENT_RETRY_ATTEMPTS:
+                    raise
+                delay = TRANSIENT_RETRY_BACKOFF * attempt
+                log.warning(
+                    "Transient error during %s (attempt %d/%d): %s; "
+                    "reconnecting, retrying in %ds...",
+                    label, attempt, TRANSIENT_RETRY_ATTEMPTS, e, delay,
+                )
+                self._drop_stale_connections()
+                time.sleep(delay)
 
     @functools.cached_property
     def proposed_ppa(self):
@@ -412,10 +463,13 @@ class LaunchpadWrapper:
         while time.time() < deadline:
             # If no explicit series, discover from published sources
             if expected is None:
-                sources = ppa.getPublishedSources(
-                    source_name=SOURCE_PACKAGE_NAME,
-                    version=version,
-                    order_by_date=True,
+                sources = self._retry_transient(
+                    "getPublishedSources",
+                    lambda: ppa.getPublishedSources(
+                        source_name=SOURCE_PACKAGE_NAME,
+                        version=version,
+                        order_by_date=True,
+                    ),
                 )
                 source_series = set()
                 for s in sources:
@@ -432,10 +486,13 @@ class LaunchpadWrapper:
                 log.info("Discovered %d series with sources: %s", len(expected), ", ".join(sorted(expected)))
 
             # Check published binaries
-            bins = ppa.getPublishedBinaries(
-                binary_name=BINARY_PACKAGE_NAME,
-                version=version,
-                order_by_date=True,
+            bins = self._retry_transient(
+                "getPublishedBinaries",
+                lambda: ppa.getPublishedBinaries(
+                    binary_name=BINARY_PACKAGE_NAME,
+                    version=version,
+                    order_by_date=True,
+                ),
             )
             published_series = set()
             for b in bins:

--- a/scripts/launchpad_copy.py
+++ b/scripts/launchpad_copy.py
@@ -19,7 +19,6 @@ import argparse
 import functools
 import logging
 import os
-import subprocess
 import sys
 import time
 from collections import defaultdict
@@ -67,8 +66,20 @@ REQUESTS = LAST_REQUESTS = 0
 
 
 def get_current_series():
-    """Get the Ubuntu series codename for the current system."""
-    return subprocess.check_output(["lsb_release", "-cs"], text=True).strip()
+    """Ubuntu series we publish the source to: the current LTS.
+
+    This must match the changelog distribution chosen by
+    generate_changelog.get_current_lts_codename() (UbuntuDistroInfo().lts()),
+    NOT the runner's own OS series. The two diverge once a newer LTS is
+    released while the CI runner is still on the previous one (e.g. runner on
+    noble while the latest LTS, and therefore the upload target, is resolute).
+    """
+    if UbuntuDistroInfo is None:
+        raise ImportError(
+            "distro-info package is required. "
+            "Install with: sudo apt install python3-distro-info"
+        )
+    return UbuntuDistroInfo().lts()
 
 
 def get_supported_series(source_series):

--- a/tests/test_generate_changelog.py
+++ b/tests/test_generate_changelog.py
@@ -1,8 +1,10 @@
+from email.utils import parseaddr
 from unittest.mock import patch
 
 from vcr_config import my_vcr
 
 from build_tools.generate_changelog import (
+    MAINTAINER,
     parse_existing_changelog,
     parse_packaging_changelog,
     kolibri_version_key,
@@ -77,7 +79,7 @@ def test_format_changelog_entry():
         ubuntu_revision=1,
         distribution="noble",
         message="New upstream release",
-        maintainer="Learning Equality \\(Learning Equality\\'s public signing key\\) <accounts@learningequality.org>>",
+        maintainer="Learning Equality <accounts@learningequality.org>",
         timestamp="Thu, 31 Oct 2025 16:09:14 +0100",
     )
     expected = """\
@@ -85,7 +87,7 @@ kolibri-source (0.19.2-0ubuntu1) noble; urgency=medium
 
   * New upstream release
 
- -- Learning Equality \\(Learning Equality\\'s public signing key\\) <accounts@learningequality.org>>  Thu, 31 Oct 2025 16:09:14 +0100
+ -- Learning Equality <accounts@learningequality.org>  Thu, 31 Oct 2025 16:09:14 +0100
 """
     assert entry == expected
 
@@ -97,10 +99,45 @@ def test_format_changelog_entry_prerelease():
         ubuntu_revision=1,
         distribution="noble",
         message="New upstream release",
-        maintainer="Learning Equality \\(Learning Equality\\'s public signing key\\) <accounts@learningequality.org>>",
+        maintainer="Learning Equality <accounts@learningequality.org>",
         timestamp="Thu, 06 Feb 2026 19:46:25 +0000",
     )
     assert "kolibri-source (0.19.2~alpha0-0ubuntu1)" in entry
+
+
+def test_maintainer_is_valid_mailbox():
+    """MAINTAINER must be a valid RFC822 mailbox.
+
+    Regression: it previously contained backslash escapes and a doubled
+    '>' (``... <accounts@learningequality.org>>``), which dpkg-genchanges
+    on newer Ubuntu series (resolute) rejects as an invalid email address,
+    aborting the Launchpad build.
+    """
+    name, email = parseaddr(MAINTAINER)
+    assert email == "accounts@learningequality.org"
+    assert name == "Learning Equality"
+    assert "\\" not in MAINTAINER
+    assert MAINTAINER.count("<") == 1
+    assert MAINTAINER.count(">") == 1
+
+
+def test_generated_entry_uses_valid_maintainer():
+    """Entries generated via the MAINTAINER constant carry a valid mailbox."""
+    with patch(
+        "build_tools.generate_changelog.get_current_lts_codename",
+        return_value="noble",
+    ):
+        entries = generate_release_entries(
+            [{"tag_name": "v0.19.2", "prerelease": False,
+              "published_at": "2025-10-31T15:09:14Z"}]
+        )
+    trailer = [ln for ln in entries[0]["text"].splitlines() if ln.startswith(" -- ")][0]
+    # Trailer format: " -- {maintainer}  {timestamp}"; maintainer and
+    # timestamp are separated by exactly two spaces.
+    maintainer = trailer[len(" -- "):].split("  ", 1)[0]
+    _, email = parseaddr(maintainer)
+    assert email == "accounts@learningequality.org"
+    assert "\\" not in maintainer
 
 
 def test_github_timestamp_to_debian():

--- a/tests/test_generate_changelog.py
+++ b/tests/test_generate_changelog.py
@@ -270,6 +270,18 @@ def test_generate_release_entries(_mock_codename):
     assert entries[0]["ubuntu_revision"] == 1
 
 
+@patch("build_tools.generate_changelog.get_current_lts_codename", return_value="noble")
+def test_generate_release_entries_respects_ubuntu_revision(_mock_codename):
+    """A bumped revision re-releases the same upstream version as -0ubuntuN."""
+    releases = [
+        {"tag_name": "v0.19.2", "prerelease": False, "published_at": "2025-10-31T15:09:14Z"},
+    ]
+    entries = generate_release_entries(releases, ubuntu_revision=2)
+    assert entries[0]["ubuntu_revision"] == 2
+    assert "0.19.2-0ubuntu2" in entries[0]["text"]
+    assert "0.19.2-0ubuntu1" not in entries[0]["text"]
+
+
 # --- Tests for CHANGELOG parsing ---
 
 SAMPLE_PACKAGING_CHANGELOG = """\

--- a/tests/test_launchpad_copy.py
+++ b/tests/test_launchpad_copy.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch, PropertyMock
 import pytest
 
 from scripts.launchpad_copy import (
+    get_current_series,
     get_supported_series,
     LaunchpadWrapper,
     PACKAGE_WHITELIST,
@@ -522,6 +523,21 @@ class TestPromote:
         assert mock_release.syncSources.call_count == 2
         # Overall result is failure because jammy failed
         assert result == 1
+
+
+# --- series helpers ---
+
+
+def test_get_current_series_returns_lts():
+    """The publish series is the current LTS, not the runner's OS series.
+
+    Regression: this used `lsb_release -cs` (the runner, e.g. noble), which
+    diverges from the upload target chosen for the changelog (the latest LTS,
+    e.g. resolute) once a new LTS ships before the runner image updates.
+    """
+    with patch("scripts.launchpad_copy.UbuntuDistroInfo") as MockUDI:
+        MockUDI.return_value.lts.return_value = "resolute"
+        assert get_current_series() == "resolute"
 
 
 # --- CLI parser tests ---

--- a/tests/test_launchpad_copy.py
+++ b/tests/test_launchpad_copy.py
@@ -4,6 +4,8 @@ All launchpadlib and distro_info calls are mocked so tests run without
 those packages installed.
 """
 
+import ssl
+
 from unittest.mock import MagicMock, patch, PropertyMock
 import pytest
 
@@ -439,6 +441,53 @@ class TestWaitForPublished:
         )
 
         assert result == 0
+
+    def test_retries_transient_connection_error(self):
+        """A transient SSL/connection blip during a poll is retried, not fatal.
+
+        Regression: a stale keep-alive socket raised ssl.SSLEOFError between
+        polls (the interval is long enough for Launchpad to drop idle
+        connections), which aborted the entire release wait.
+        """
+        wrapper, mock_ppa, _, _ = make_wrapper_with_mock_lp()
+
+        source = make_mock_source(series_name="noble")
+        mock_ppa.getPublishedSources.return_value = [source]
+
+        mock_binary = MagicMock()
+        mock_binary.status = "Published"
+        mock_binary.distro_arch_series_link = "https://api.launchpad.net/devel/ubuntu/noble/amd64"
+        # First poll raises a transient error; the retry reconnects and succeeds.
+        mock_ppa.getPublishedBinaries.side_effect = [
+            ssl.SSLEOFError("EOF occurred in violation of protocol (_ssl.c:2406)"),
+            [mock_binary],
+        ]
+
+        wrapper.get_ppa = MagicMock(return_value=mock_ppa)
+
+        with patch("scripts.launchpad_copy.time.sleep"):
+            result = wrapper.wait_for_published(
+                "0.19.3-0ubuntu1", series=["noble"], timeout=5, interval=1,
+            )
+
+        assert result == 0
+        assert mock_ppa.getPublishedBinaries.call_count == 2
+
+    def test_transient_errors_propagate_after_exhausting_retries(self):
+        """A transient error that never clears is raised, not silently ignored."""
+        wrapper, mock_ppa, _, _ = make_wrapper_with_mock_lp()
+
+        source = make_mock_source(series_name="noble")
+        mock_ppa.getPublishedSources.return_value = [source]
+        mock_ppa.getPublishedBinaries.side_effect = ssl.SSLEOFError("boom")
+
+        wrapper.get_ppa = MagicMock(return_value=mock_ppa)
+
+        with patch("scripts.launchpad_copy.time.sleep"):
+            with pytest.raises(ssl.SSLEOFError):
+                wrapper.wait_for_published(
+                    "0.19.3-0ubuntu1", series=["noble"], timeout=5, interval=1,
+                )
 
 
 # --- promote tests ---

--- a/tests/test_launchpad_copy.py
+++ b/tests/test_launchpad_copy.py
@@ -13,6 +13,8 @@ from scripts.launchpad_copy import (
     PACKAGE_WHITELIST,
     PROPOSED_PPA_NAME,
     RELEASE_PPA_NAME,
+    SOURCE_PACKAGE_NAME,
+    BINARY_PACKAGE_NAME,
     POCKET,
     build_parser,
 )
@@ -136,7 +138,7 @@ class TestCheckSource:
 
         wrapper.get_ppa = MagicMock(return_value=mock_ppa)
 
-        result = wrapper.check_source("kolibri-source", "0.19.3-0ubuntu1")
+        result = wrapper.check_source("0.19.3-0ubuntu1")
         assert result == 0
 
     def test_returns_1_when_source_missing(self):
@@ -145,7 +147,7 @@ class TestCheckSource:
 
         wrapper.get_ppa = MagicMock(return_value=mock_ppa)
 
-        result = wrapper.check_source("kolibri-source", "0.19.3-0ubuntu1")
+        result = wrapper.check_source("0.19.3-0ubuntu1")
         assert result == 1
 
     def test_ignores_deleted_sources(self):
@@ -155,7 +157,7 @@ class TestCheckSource:
 
         wrapper.get_ppa = MagicMock(return_value=mock_ppa)
 
-        result = wrapper.check_source("kolibri-source", "0.19.3-0ubuntu1")
+        result = wrapper.check_source("0.19.3-0ubuntu1")
         assert result == 1
 
     def test_ignores_superseded_sources(self):
@@ -165,7 +167,7 @@ class TestCheckSource:
 
         wrapper.get_ppa = MagicMock(return_value=mock_ppa)
 
-        result = wrapper.check_source("kolibri-source", "0.19.3-0ubuntu1")
+        result = wrapper.check_source("0.19.3-0ubuntu1")
         assert result == 1
 
     def test_custom_ppa_name(self):
@@ -174,7 +176,7 @@ class TestCheckSource:
 
         wrapper.get_ppa = MagicMock(return_value=mock_ppa)
 
-        wrapper.check_source("kolibri-source", "0.19.3-0ubuntu1", ppa_name="kolibri")
+        wrapper.check_source("0.19.3-0ubuntu1", ppa_name="kolibri")
 
         wrapper.get_ppa.assert_called_with("kolibri")
 
@@ -184,7 +186,7 @@ class TestCheckSource:
 
         wrapper.get_ppa = MagicMock(return_value=mock_ppa)
 
-        result = wrapper.check_source("kolibri-source", "0.19.3-0ubuntu1")
+        result = wrapper.check_source("0.19.3-0ubuntu1")
         assert result == 2
 
 
@@ -325,11 +327,36 @@ class TestWaitForPublished:
         wrapper.get_ppa = MagicMock(return_value=mock_ppa)
 
         result = wrapper.wait_for_published(
-            "kolibri-source", "0.19.3-0ubuntu1",
+            "0.19.3-0ubuntu1",
             series=["noble"], timeout=5, interval=1,
         )
 
         assert result == 0
+
+    def test_queries_binaries_by_binary_name(self):
+        """Binaries are queried by the binary name, not the source name.
+
+        Regression: wait_for_published used to query getPublishedBinaries
+        with the source name ("kolibri-source"), which never matches the
+        actual binary ("kolibri"), so the wait could only ever time out.
+        """
+        assert BINARY_PACKAGE_NAME != SOURCE_PACKAGE_NAME
+
+        wrapper, mock_ppa, _, _ = make_wrapper_with_mock_lp()
+        source = make_mock_source(series_name="noble")
+        mock_ppa.getPublishedSources.return_value = [source]
+        mock_binary = MagicMock()
+        mock_binary.status = "Published"
+        mock_binary.distro_arch_series_link = "https://api.launchpad.net/devel/ubuntu/noble/amd64"
+        mock_ppa.getPublishedBinaries.return_value = [mock_binary]
+        wrapper.get_ppa = MagicMock(return_value=mock_ppa)
+
+        # series=None so the source-discovery branch also runs
+        result = wrapper.wait_for_published("0.19.3-0ubuntu1", timeout=5, interval=1)
+
+        assert result == 0
+        assert mock_ppa.getPublishedSources.call_args.kwargs["source_name"] == SOURCE_PACKAGE_NAME
+        assert mock_ppa.getPublishedBinaries.call_args.kwargs["binary_name"] == BINARY_PACKAGE_NAME
 
     def test_returns_1_on_timeout(self):
         wrapper, mock_ppa, _, _ = make_wrapper_with_mock_lp()
@@ -341,7 +368,7 @@ class TestWaitForPublished:
         wrapper.get_ppa = MagicMock(return_value=mock_ppa)
 
         result = wrapper.wait_for_published(
-            "kolibri-source", "0.19.3-0ubuntu1",
+            "0.19.3-0ubuntu1",
             series=["noble"], timeout=1, interval=1,
         )
 
@@ -365,7 +392,7 @@ class TestWaitForPublished:
         wrapper.get_ppa = MagicMock(return_value=mock_ppa)
 
         result = wrapper.wait_for_published(
-            "kolibri-source", "0.19.3-0ubuntu1", timeout=5, interval=1,
+            "0.19.3-0ubuntu1", timeout=5, interval=1,
         )
 
         assert result == 0
@@ -386,7 +413,7 @@ class TestWaitForPublished:
 
         # Only waiting for noble, not jammy
         result = wrapper.wait_for_published(
-            "kolibri-source", "0.19.3-0ubuntu1",
+            "0.19.3-0ubuntu1",
             series=["noble"], timeout=5, interval=1,
         )
 
@@ -407,7 +434,7 @@ class TestWaitForPublished:
         wrapper.get_ppa = MagicMock(return_value=mock_ppa)
 
         result = wrapper.wait_for_published(
-            "kolibri-source", "0.19.3-0ubuntu1", timeout=5, interval=1,
+            "0.19.3-0ubuntu1", timeout=5, interval=1,
         )
 
         assert result == 0
@@ -504,12 +531,11 @@ class TestBuildParser:
     def test_check_source_args(self):
         parser = build_parser()
         args = parser.parse_args([
-            "check-source", "--package", "kolibri-source",
+            "check-source",
             "--version", "0.19.3-0ubuntu1",
         ])
         assert args.command == "check-source"
         assert args.version == "0.19.3-0ubuntu1"
-        assert args.package == "kolibri-source"
         assert args.ppa == PROPOSED_PPA_NAME
 
     def test_copy_to_series_args(self):
@@ -527,7 +553,6 @@ class TestBuildParser:
         parser = build_parser()
         args = parser.parse_args([
             "wait-for-published",
-            "--package", "kolibri-source",
             "--version", "0.19.3-0ubuntu1",
             "--timeout", "3600", "--interval", "30",
             "--series", "noble", "jammy",


### PR DESCRIPTION
## Summary

Fixes three bugs in the PPA release automation (added in #160) that broke the source-package build/upload and the publish-wait steps. They surfaced now because the prerelease target series rolled over to 26.04 (resolute), whose stricter `dpkg` exposed a long-dormant malformed maintainer field.

- **Invalid changelog maintainer.** The `MAINTAINER` constant produced an invalid RFC822 mailbox (backslash escapes + a doubled `>`). Newer `dpkg-genchanges` rejects it, aborting the Launchpad build *after* the `.deb` is already built. Replaced with `Learning Equality <accounts@learningequality.org>` — same email as the signing-key UID, only the GPG comment dropped.
- **`wait-for-published` could only ever time out.** It queried published *binaries* by the *source* name (`kolibri-source`), but the binary package is `kolibri`. Now queries sources by source name and binaries by binary name. This also removes the unused `--package` argument (the package set is fixed in `PACKAGE_WHITELIST`), whose hand-threading had caused missing-arg failures at three call sites (two in `prerelease.yml`, one in `release_ppa.yml`).
- **Prerelease signing filename.** `build.sh` derived the Debian version with a regex that never matched, so a prerelease like `0.20.0-alpha1` kept its hyphen instead of the `~` form dpkg uses — `signfiles` then looked for a nonexistent file. Stable releases were unaffected (the broken regex was a no-op).

The target series staying at the latest LTS (resolute) is intentional and unchanged.

## References

- Automation introduced by #160 (`automate-ppa-releases`)
- Follows #163 (added the missing `build-essential` to the same workflow)

## Reviewer guidance

- The real end-to-end check is a green run of the **Pre-release to kolibri-proposed PPA** workflow: the Launchpad build should now complete past `dpkg-genchanges`, and the **Wait for source package builds** job should detect published binaries instead of timing out.
- Worth a careful look:
  - `launchpad_copy.py` `wait_for_published` — confirm sources are queried by `SOURCE_PACKAGE_NAME` and binaries by `BINARY_PACKAGE_NAME` (the prior code conflated them, and the old tests masked it by returning a binary regardless of the queried name).
  - `build.sh` `DEB_VERSION` — the conversion now matches `version_to_debian` in `generate_changelog.py` and the workflow's own `sed`.
- Tests: `pytest` (67 tests) passes locally; new regression tests pin the maintainer mailbox and the binary-name query.

## AI usage

I used Claude Code to diagnose the failing CI/Launchpad runs and implement the fixes. It traced each failure to root cause (the implicit `dpkg` maintainer/email validation, the source-vs-binary name conflation, the no-op version regex), cross-checked every `launchpad_copy.py` invocation across the workflows against the argparse spec, and proposed the fixes. I reviewed each diagnosis, chose the design direction (drop `--package` and hardcode the names rather than thread the arg through), and verified the test suite.